### PR TITLE
Add consumer proving scaffolds for #1

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Consumer proving rail notes
+    url: https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/blob/develop/docs/CONSUMER_PROVING_RAIL.md
+    about: Start here for the canonical, org-fork, and personal-fork operating model.

--- a/.github/ISSUE_TEMPLATE/template-evolution.yml
+++ b/.github/ISSUE_TEMPLATE/template-evolution.yml
@@ -1,0 +1,28 @@
+name: Template evolution
+about: Track a concrete improvement to the hosted-first cookiecutter template surface.
+title: '[Template]: '
+labels:
+  - enhancement
+  - documentation
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What should change in the template?
+    validations:
+      required: true
+  - type: textarea
+    id: hosted-proof
+    attributes:
+      label: Hosted proof
+      description: Which hosted Linux/Windows lanes should prove this change?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: What will make this change done?
+    validations:
+      required: true

--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -43,9 +43,12 @@ jobs:
             throw "Rendered project was not created at $generatedRoot"
           }
           $required = @(
+            'AGENTS.md',
             'README.md',
             'LICENSE',
             '.gitignore',
+            '.github/ISSUE_TEMPLATE/config.yml',
+            '.github/ISSUE_TEMPLATE/work-item.yml',
             '.github/workflows/validate.yml'
           )
           foreach ($relativePath in $required) {

--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ This repository is intended to be used in two ways:
 - BSD-3 license at the root and in generated consumers
 - `cookiecutter.json` prompts for repo identity and branch defaults
 - a generated starter project with:
+  - `AGENTS.md`
   - `README.md`
   - `LICENSE`
   - `.gitignore`
+  - issue templates
+  - consumer proving rail docs
   - hosted Linux + Windows validation workflow
 - a self-validation workflow that renders the template on both `ubuntu-latest`
   and `windows-latest`
@@ -31,7 +34,11 @@ cookiecutter https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate.
 For unattended automation:
 
 ```bash
-cookiecutter https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate.git   --no-input   project_name="LabVIEW Hosted CI Sample"   repo_slug="labview-hosted-ci-sample"   github_owner="LabVIEW-Community-CI-CD"
+cookiecutter https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate.git
+  --no-input
+  project_name="LabVIEW Hosted CI Sample"
+  repo_slug="labview-hosted-ci-sample"
+  github_owner="LabVIEW-Community-CI-CD"
 ```
 
 ## Direction
@@ -40,3 +47,6 @@ This repository is the mass-consumer cookiecutter surface for hosted GitHub CI
 bootstrapping. Heavy compare/runtime orchestration should remain in the
 platform repos; this template should stay focused on portable consumer setup and
 hosted proving lanes.
+
+See [docs/CONSUMER_PROVING_RAIL.md](docs/CONSUMER_PROVING_RAIL.md) for the
+canonical repo, organization-fork, and personal-fork operating model.

--- a/docs/CONSUMER_PROVING_RAIL.md
+++ b/docs/CONSUMER_PROVING_RAIL.md
@@ -1,0 +1,32 @@
+# Consumer Proving Rail
+
+`LabviewGitHubCiTemplate` is designed around a three-repository proving model:
+
+1. canonical template repo
+2. organization fork proving lane
+3. personal fork proving lane
+
+## Why
+
+This keeps the canonical template stable while still giving maintainers and
+agents space to run manual workflows, parallel consumer proof, and fork-specific
+standing-priority work.
+
+## Operating Model
+
+- `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate`
+  - canonical template source
+  - owns template semantics and release direction
+- `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork`
+  - organization proving rail
+  - good for shared manual validation and fork-scoped CI exercises
+- `svelderrainruiz/LabviewGitHubCiTemplate`
+  - personal proving rail
+  - good for manual dispatches, experimentation, and future remote-worker
+    identity routing
+
+## Labels
+
+- canonical repos should use `standing-priority`
+- fork repos should prefer `fork-standing-priority`
+- hosted-first CI should remain the authoritative proving plane

--- a/{{ cookiecutter.repo_slug }}/.github/ISSUE_TEMPLATE/config.yml
+++ b/{{ cookiecutter.repo_slug }}/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Consumer proving rail
+    url: https://github.com/{{ cookiecutter.github_owner }}/{{ cookiecutter.repo_slug }}/blob/{{ cookiecutter.default_branch }}/docs/CONSUMER_PROVING_RAIL.md
+    about: Review the canonical and fork-lane model before opening a new work item.

--- a/{{ cookiecutter.repo_slug }}/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/{{ cookiecutter.repo_slug }}/.github/ISSUE_TEMPLATE/work-item.yml
@@ -1,0 +1,27 @@
+name: Work item
+about: Track a concrete hosted-first change for this generated repository.
+title: '[Work]: '
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What needs to change?
+    validations:
+      required: true
+  - type: textarea
+    id: hosted_lanes
+    attributes:
+      label: Hosted lanes
+      description: Which hosted Linux or Windows lanes should prove this work?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: What evidence makes this done?
+    validations:
+      required: true

--- a/{{ cookiecutter.repo_slug }}/AGENTS.md
+++ b/{{ cookiecutter.repo_slug }}/AGENTS.md
@@ -1,0 +1,25 @@
+# Agent Handbook
+
+This repository was generated from `LabviewGitHubCiTemplate`.
+
+## Primary Directive
+
+- Work the issue carrying the active standing label for the current repository
+  context:
+  - canonical/upstream: `standing-priority`
+  - forks: `fork-standing-priority` with fallback to `standing-priority`
+- Prefer hosted Linux and hosted Windows proving lanes.
+- Treat local/manual execution as acceleration, not as the authoritative release
+  surface.
+
+## Branch Model
+
+- default integration branch: `{{ cookiecutter.default_branch }}`
+- canonical repo owns template/product direction
+- forks are proving lanes and should avoid long-lived drift from upstream
+
+## Working Rules
+
+- keep workflows portable across hosted Linux and hosted Windows
+- keep generated docs and issue templates in sync with the proving model
+- prefer issue-driven work and visible acceptance criteria over ad hoc notes

--- a/{{ cookiecutter.repo_slug }}/docs/CONSUMER_PROVING_RAIL.md
+++ b/{{ cookiecutter.repo_slug }}/docs/CONSUMER_PROVING_RAIL.md
@@ -1,0 +1,20 @@
+# Consumer Proving Rail
+
+This generated repository assumes a hosted-first proving model.
+
+## Recommended topology
+
+1. canonical repo on `{{ cookiecutter.default_branch }}`
+2. optional same-owner fork for shared proving
+3. optional personal fork for manual proving and remote worker routing
+
+## Labels
+
+- canonical repos: `standing-priority`
+- forks: `fork-standing-priority`
+
+## Hosted-first rule
+
+Hosted Linux and hosted Windows workflows should be the authoritative proof
+surfaces. Local/manual lanes can accelerate work, but they should not silently
+replace hosted evidence.


### PR DESCRIPTION
## Summary
- add consumer-proving rail documentation to the template repo
- add issue templates for the canonical template repo
- add generated `AGENTS.md`, issue templates, and proving-rail docs to consumer output
- extend template-smoke so these new generated files are required in the render proof

## Validation
- local cookiecutter render with required-file verification
