### PR TITLE
Add comparevi integration guidance for #3

### DIFF
--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -47,6 +47,7 @@ jobs:
             'README.md',
             'LICENSE',
             '.gitignore',
+            'docs/COMPAREVI_PLATFORM_INTEGRATION.md',
             'docs/CONSUMER_PROVING_RAIL.md',
             '.github/ISSUE_TEMPLATE/config.yml',
             '.github/ISSUE_TEMPLATE/work-item.yml',

--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ hosted proving lanes.
 
 See [docs/CONSUMER_PROVING_RAIL.md](docs/CONSUMER_PROVING_RAIL.md) for the
 canonical repo, organization-fork, and personal-fork operating model.
+
+See [docs/COMPAREVI_PLATFORM_INTEGRATION.md](docs/COMPAREVI_PLATFORM_INTEGRATION.md)
+for the intended boundary between generated consumers and the comparevi
+platform repos.

--- a/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -1,0 +1,41 @@
+# CompareVI Platform Integration
+
+`LabviewGitHubCiTemplate` should help downstream consumers compose with the
+CompareVI platform without copying platform ownership into the consumer repo.
+
+## Ownership Boundary
+
+- `compare-vi-cli-action`
+  - owns CompareVI runtime/tooling orchestration
+  - owns hosted Linux and Windows execution surfaces
+  - owns release pins for CompareVI.Tools
+- `comparevi-history`
+  - owns review bundle compilation and reviewer-facing rendering
+  - owns pull-request diagnostics publication surfaces
+- generated consumer repos
+  - own their repository-specific triggers, docs, and proving decisions
+  - should stay hosted-first
+  - should not fork platform runtime logic into local scripts by default
+
+## Reference Consumer
+
+Use `LabVIEW-Community-CI-CD/labview-icon-editor-demo` on `develop` as the
+reference downstream consumer proof surface.
+
+That repo is the right place to study how a consumer composes with:
+
+- CompareVI.Tools release pins from `compare-vi-cli-action`
+- reviewer-facing diagnostics from `comparevi-history`
+- hosted proving lanes instead of self-hosted assumptions
+
+## Template Guidance
+
+Generated consumers should:
+
+1. pin released platform artifacts instead of copying Docker/runtime helpers
+2. keep hosted Linux and hosted Windows as the authoritative proving surfaces
+3. add comparevi integration as an opt-in lane after the baseline hosted
+   workflow is healthy
+
+This keeps the consumer template portable while still providing a clear path to
+adopt the proven comparevi platform.

--- a/{{ cookiecutter.repo_slug }}/README.md
+++ b/{{ cookiecutter.repo_slug }}/README.md
@@ -15,3 +15,9 @@ in `.github/workflows/validate.yml`.
 
 The initial workflow is intentionally small so teams can add LabVIEW-specific
 steps without first having to bootstrap a cross-OS GitHub Actions skeleton.
+
+## CompareVI Integration
+
+If this repository later opts into CompareVI diagnostics, start with
+`docs/COMPAREVI_PLATFORM_INTEGRATION.md` and keep the platform/runtime boundary
+intact instead of copying platform-owned scripts into the consumer repo.

--- a/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -1,0 +1,28 @@
+# CompareVI Platform Integration
+
+This generated repository should compose with the comparevi platform as a
+consumer, not as a second runtime owner.
+
+## Boundary
+
+- `compare-vi-cli-action` owns runtime/tooling orchestration and released
+  CompareVI.Tools assets
+- `comparevi-history` owns reviewer-facing history bundle/render surfaces
+- this repository should own only its consumer-specific workflow triggers,
+  proving decisions, and documentation
+
+## Reference Consumer
+
+Use `LabVIEW-Community-CI-CD/labview-icon-editor-demo` on `develop` as the
+reference downstream consumer example.
+
+That reference shows the intended hosted-first relationship to the comparevi
+platform without copying platform-owned runtime logic into the consumer repo.
+
+## Adoption Rule
+
+Treat comparevi integration as an opt-in lane:
+
+1. keep the baseline hosted Linux and hosted Windows consumer workflow healthy
+2. pin released comparevi artifacts
+3. add comparevi-specific proving only when the repository is ready for it


### PR DESCRIPTION
## Summary
- add comparevi platform boundary docs to the template repo
- add generated comparevi integration guidance for consumers
- point consumers at the proven downstream reference surface instead of copying platform runtime ownership
- extend template-smoke to require the new generated integration doc

## Validation
- local cookiecutter render with generated integration-doc verification
