### PR TITLE
Add pinned compare-vi consumer smoke for #8

### DIFF
--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -49,6 +49,7 @@ jobs:
             '.gitignore',
             'docs/COMPAREVI_PLATFORM_INTEGRATION.md',
             'docs/CONSUMER_PROVING_RAIL.md',
+            'tests/fixtures/comparevi/placeholder.vi',
             '.github/ISSUE_TEMPLATE/config.yml',
             '.github/ISSUE_TEMPLATE/work-item.yml',
             '.github/workflows/validate.yml'
@@ -67,7 +68,9 @@ jobs:
             'release/*',
             '### Consumer proving plan',
             'Hosted Linux consumer lane',
-            'Hosted Windows consumer lane'
+            'Hosted Windows consumer lane',
+            'uses: LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3',
+            'shortCircuitedIdentical'
           )
           foreach ($snippet in $requiredSnippets) {
             if ($workflowContent -notlike "*$snippet*") {
@@ -81,3 +84,41 @@ jobs:
         with:
           name: template-smoke-${{ matrix.os }}
           path: ${{ steps.render.outputs.generated_root }}
+
+  comparevi-consumer-smoke:
+    name: comparevi-consumer-smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v5
+
+      - id: comparevi
+        name: CompareVI consumer smoke
+        uses: LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3
+        with:
+          base: tests/fixtures/comparevi/placeholder.vi
+          head: tests/fixtures/comparevi/placeholder.vi
+          fail-on-diff: 'false'
+
+      - name: Assert comparevi short-circuit
+        shell: pwsh
+        run: |
+          if ('${{ steps.comparevi.outputs.shortCircuitedIdentical }}' -ne 'true') {
+            throw 'Expected compare-vi consumer smoke to short-circuit identical inputs.'
+          }
+          if ('${{ steps.comparevi.outputs.diff }}' -ne 'false') {
+            throw 'Expected compare-vi consumer smoke to report no diff for identical inputs.'
+          }
+          if ($env:GITHUB_STEP_SUMMARY) {
+            @(
+              '### CompareVI consumer smoke',
+              '',
+              '- pinned_ref: `LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3`',
+              ('- runner_os: `{0}`' -f $env:RUNNER_OS),
+              ('- shortCircuitedIdentical: `{0}`' -f '${{ steps.comparevi.outputs.shortCircuitedIdentical }}'),
+              ('- diff: `{0}`' -f '${{ steps.comparevi.outputs.diff }}')
+            ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+          }

--- a/tests/fixtures/comparevi/placeholder.vi
+++ b/tests/fixtures/comparevi/placeholder.vi
@@ -1,0 +1,1 @@
+Template placeholder VI fixture for compare-vi consumer smoke.

--- a/{{ cookiecutter.repo_slug }}/.github/workflows/validate.yml
+++ b/{{ cookiecutter.repo_slug }}/.github/workflows/validate.yml
@@ -37,9 +37,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - id: comparevi
+        name: CompareVI consumer smoke
+        uses: LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3
+        with:
+          base: tests/fixtures/comparevi/placeholder.vi
+          head: tests/fixtures/comparevi/placeholder.vi
+          fail-on-diff: 'false'
       - name: Hosted Linux consumer lane
         shell: pwsh
         run: |
+          if ('{% raw %}${{ steps.comparevi.outputs.shortCircuitedIdentical }}{% endraw %}' -ne 'true') {
+            throw 'Expected compare-vi consumer smoke to short-circuit identical inputs on hosted Linux.'
+          }
           Write-Host 'Hosted Linux consumer lane is ready for project-specific LabVIEW automation.'
           Write-Host ('Repository: {0}/{1}' -f '{% raw %}${{ github.repository_owner }}{% endraw %}', '{% raw %}${{ github.event.repository.name }}{% endraw %}')
           Write-Host ('Ref: {0}' -f '{% raw %}${{ github.ref }}{% endraw %}')
@@ -48,7 +58,9 @@ jobs:
               '### Hosted Linux consumer lane',
               '',
               '- status: `ready`',
-              ('- runner_os: `{0}`' -f $env:RUNNER_OS)
+              ('- runner_os: `{0}`' -f $env:RUNNER_OS),
+              '- comparevi_ref: `LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3`',
+              ('- shortCircuitedIdentical: `{0}`' -f '{% raw %}${{ steps.comparevi.outputs.shortCircuitedIdentical }}{% endraw %}')
             ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           }
 
@@ -57,9 +69,19 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
+      - id: comparevi
+        name: CompareVI consumer smoke
+        uses: LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3
+        with:
+          base: tests/fixtures/comparevi/placeholder.vi
+          head: tests/fixtures/comparevi/placeholder.vi
+          fail-on-diff: 'false'
       - name: Hosted Windows consumer lane
         shell: powershell
         run: |
+          if ('{% raw %}${{ steps.comparevi.outputs.shortCircuitedIdentical }}{% endraw %}' -ne 'true') {
+            throw 'Expected compare-vi consumer smoke to short-circuit identical inputs on hosted Windows.'
+          }
           Write-Host 'Hosted Windows consumer lane is ready for project-specific LabVIEW automation.'
           Write-Host ('Repository: {0}/{1}' -f '{% raw %}${{ github.repository_owner }}{% endraw %}', '{% raw %}${{ github.event.repository.name }}{% endraw %}')
           Write-Host ('Ref: {0}' -f '{% raw %}${{ github.ref }}{% endraw %}')
@@ -68,6 +90,8 @@ jobs:
               '### Hosted Windows consumer lane',
               '',
               '- status: `ready`',
-              ('- runner_os: `{0}`' -f $env:RUNNER_OS)
+              ('- runner_os: `{0}`' -f $env:RUNNER_OS),
+              '- comparevi_ref: `LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3`',
+              ('- shortCircuitedIdentical: `{0}`' -f '{% raw %}${{ steps.comparevi.outputs.shortCircuitedIdentical }}{% endraw %}')
             ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           }

--- a/{{ cookiecutter.repo_slug }}/tests/fixtures/comparevi/placeholder.vi
+++ b/{{ cookiecutter.repo_slug }}/tests/fixtures/comparevi/placeholder.vi
@@ -1,0 +1,1 @@
+Template placeholder VI fixture for compare-vi consumer smoke.


### PR DESCRIPTION
Implements the first real compare-vi consumer baseline for this template repo.

What changes:
- adds a pinned compare-vi consumer smoke lane to the template repo itself using `LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3`
- carries the same pinned smoke lane and placeholder `.vi` fixture into the generated template workflow
- extends template self-validation so rendered consumers must include the compare-vi workflow reference and fixture path

Validation:
- Python-based local cookiecutter render proof passed and confirmed the generated workflow contains the pinned compare-vi ref plus the placeholder fixture
- `git diff --check`

Refs #8
