### PR TITLE
Clarify fork consumer proof contract for #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ hosted proving lanes.
 See [docs/CONSUMER_PROVING_RAIL.md](docs/CONSUMER_PROVING_RAIL.md) for the
 canonical repo, organization-fork, and personal-fork operating model.
 
+Current fork consumer proving guidance:
+
+- keep fork `develop` aligned to canonical `develop`
+- use manual `template-smoke` dispatches on aligned fork `develop` as the
+  supported fork proof path
+- treat fork-local `pull_request` proof as tracked investigation work until
+  [issue #10](https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/issues/10)
+  is resolved
+
 See [docs/COMPAREVI_PLATFORM_INTEGRATION.md](docs/COMPAREVI_PLATFORM_INTEGRATION.md)
 for the intended boundary between generated consumers and the comparevi
 platform repos.

--- a/docs/CONSUMER_PROVING_RAIL.md
+++ b/docs/CONSUMER_PROVING_RAIL.md
@@ -25,6 +25,23 @@ standing-priority work.
   - good for manual dispatches, experimentation, and future remote-worker
     identity routing
 
+## Current Proof Contract
+
+- canonical template repo
+  - `template-smoke` on `push`, `pull_request`, and `workflow_dispatch` is the
+    authoritative template-self-validation surface
+- consumer forks
+  - keep fork `develop` aligned to canonical `develop`
+  - treat `workflow_dispatch` on `template-smoke` from aligned `develop` as the
+    currently supported fork consumer proof lane
+  - treat fork-local `pull_request` proof as an active investigation, not a
+    guaranteed signal, until
+    [issue #10](https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/issues/10)
+    is resolved
+- generated consumers
+  - remain the hosted-first proving target for downstream validation
+  - should not inherit fork-only proving assumptions without explicit evidence
+
 ## Labels
 
 - canonical repos should use `standing-priority`


### PR DESCRIPTION
## Summary
Clarify the currently supported fork consumer proof contract while issue #10 investigates missing `pull_request` runs on consumer forks.

## What this changes
- states that aligned fork `develop` + manual `template-smoke` dispatch is the supported fork proof path today
- states that fork-local PR proof is still under active investigation in #10
- keeps the generated consumer rail separate from fork-only assumptions

Closes #10
