### PR TITLE
#13 Add canonical template handoff entrypoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Agent Handbook
+
+This file is the bounded agent entrypoint for the canonical
+`LabviewGitHubCiTemplate` repository.
+Keep it short, stable, and focused on the contract future agents need.
+
+## Primary Directive
+
+- Work the issue carrying `standing-priority` in the canonical template repo.
+- Start from canonical `develop`.
+- Inspect open issues first.
+- Inspect the latest supported `template-smoke` proof state before opening or
+  refreshing work.
+- Treat `queue-empty` as a valid monitoring state. If no eligible issue exists,
+  do not invent new work.
+- Consumer forks are proving rails, not the default working context.
+
+## First Actions
+
+1. Confirm you are on canonical `develop`.
+2. Check open issues in `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate`.
+3. Check the latest `template-smoke` state for:
+   - canonical repo
+   - `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork`
+   - `svelderrainruiz/LabviewGitHubCiTemplate`
+4. If no eligible issue exists, remain in monitoring mode.
+5. If an eligible issue exists, treat that issue as the top objective.
+
+## Monitoring Contract
+
+- canonical template repo open issues are the primary wake signal
+- both consumer forks must stay aligned to canonical `develop`
+- supported consumer proof is `workflow_dispatch` on `template-smoke` from
+  aligned fork `develop`
+- fork-local `pull_request` validation remains unsupported and must not reopen
+  work by itself
+- generated consumers inherit their own `AGENTS.md`; this root file governs the
+  canonical template repo itself
+
+## Working Rules
+
+- keep the template repo lightweight and docs/workflow-driven
+- do not import comparevi platform tooling into this repository unless the repo
+  explicitly adopts it later
+- prefer issue-driven work over ad hoc local notes
+- keep hosted proving authoritative
+
+## References
+
+- `AGENT_HANDOFF.txt`
+- `README.md`
+- `docs/CONSUMER_PROVING_RAIL.md`
+- `docs/COMPAREVI_PLATFORM_INTEGRATION.md`

--- a/AGENT_HANDOFF.txt
+++ b/AGENT_HANDOFF.txt
@@ -1,0 +1,50 @@
+# Agent Handoff
+
+This file is the stable handoff entrypoint for the canonical
+`LabviewGitHubCiTemplate` repository.
+It is not a running status log.
+
+Live state for this lightweight repo is determined from GitHub evidence:
+- open issues in the canonical template repo
+- latest supported `template-smoke` results on canonical and consumer forks
+- canonical/fork `develop` alignment
+
+## First Actions
+
+1. Start from canonical `develop`.
+2. Inspect open issues in `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate`.
+3. Inspect the latest supported `template-smoke` state on:
+   - canonical template repo
+   - organization fork
+   - personal fork
+4. If no eligible issue exists, remain in monitoring mode.
+5. If an eligible issue exists, use that issue as the top objective.
+
+## Live State Surfaces
+
+- Open issues:
+  `gh issue list --repo LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate --state open`
+- Canonical workflow state:
+  `gh run list --repo LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate --workflow template-smoke.yml --limit 5`
+- Organization fork supported proof:
+  `gh run list --repo LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork --workflow template-smoke.yml --branch develop --event workflow_dispatch --limit 5`
+- Personal fork supported proof:
+  `gh run list --repo svelderrainruiz/LabviewGitHubCiTemplate --workflow template-smoke.yml --branch develop --event workflow_dispatch --limit 5`
+
+## Working Rules
+
+- `queue-empty` is a valid terminal monitoring state
+- canonical template open issues are the primary wake signal
+- forks are proving rails, not the default execution target
+- supported fork proof is `workflow_dispatch` `template-smoke` on aligned fork
+  `develop`
+- fork-local `pull_request` validation remains unsupported and must not reopen
+  work by itself
+
+## When Handoff Looks Wrong
+
+1. Re-check canonical open issues.
+2. Re-check canonical and fork `template-smoke` runs.
+3. Re-check fork `develop` alignment to canonical `develop`.
+4. Use `README.md` and `docs/CONSUMER_PROVING_RAIL.md` for the durable repo
+   contract.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,28 @@ cookiecutter https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate.
   github_owner="LabVIEW-Community-CI-CD"
 ```
 
+## Canonical Operating Contract
+
+This canonical repository is intentionally lightweight.
+It should remain docs/workflow-driven and should not absorb comparevi platform
+control-plane tooling unless it explicitly adopts that direction later.
+
+Future agents should treat the canonical template repo this way:
+
+- start from canonical `develop`
+- inspect open issues first
+- inspect the latest supported `template-smoke` state
+- if no eligible issue exists, remain in monitoring mode
+- if an eligible issue exists, use that issue as the top objective
+
+Root repo agent entrypoints live in:
+
+- `AGENTS.md`
+- `AGENT_HANDOFF.txt`
+
+Generated consumers still inherit their own `AGENTS.md`; the root files above
+only govern the canonical template repository itself.
+
 ## Direction
 
 This repository is the mass-consumer cookiecutter surface for hosted GitHub CI
@@ -56,9 +78,10 @@ Current fork consumer proving guidance:
 - keep fork `develop` aligned to canonical `develop`
 - use manual `template-smoke` dispatches on aligned fork `develop` as the
   supported fork proof path
-- treat fork-local `pull_request` proof as tracked investigation work until
-  [issue #10](https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/issues/10)
-  is resolved
+- treat fork-local `pull_request` proof as unsupported and do not reopen work
+  from it by itself
+- when the canonical template queue is empty, monitoring-only is the correct
+  terminal state
 
 See [docs/COMPAREVI_PLATFORM_INTEGRATION.md](docs/COMPAREVI_PLATFORM_INTEGRATION.md)
 for the intended boundary between generated consumers and the comparevi

--- a/docs/CONSUMER_PROVING_RAIL.md
+++ b/docs/CONSUMER_PROVING_RAIL.md
@@ -17,13 +17,17 @@ standing-priority work.
 - `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate`
   - canonical template source
   - owns template semantics and release direction
+  - uses `standing-priority`
+  - open issues are the primary wake signal
 - `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork`
   - organization proving rail
   - good for shared manual validation and fork-scoped CI exercises
+  - should stay aligned to canonical `develop`
 - `svelderrainruiz/LabviewGitHubCiTemplate`
   - personal proving rail
   - good for manual dispatches, experimentation, and future remote-worker
     identity routing
+  - should stay aligned to canonical `develop`
 
 ## Current Proof Contract
 
@@ -33,14 +37,25 @@ standing-priority work.
 - consumer forks
   - keep fork `develop` aligned to canonical `develop`
   - treat `workflow_dispatch` on `template-smoke` from aligned `develop` as the
-    currently supported fork consumer proof lane
-  - treat fork-local `pull_request` proof as an active investigation, not a
-    guaranteed signal, until
-    [issue #10](https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/issues/10)
-    is resolved
+    supported fork consumer proof lane
+  - treat fork-local `pull_request` proof as unsupported and never reopen work
+    from it by itself
 - generated consumers
   - remain the hosted-first proving target for downstream validation
   - should not inherit fork-only proving assumptions without explicit evidence
+
+## Monitoring Mode
+
+When the canonical template repo has no eligible open issue, monitoring-only is
+correct.
+In that state:
+
+- do not invent new work
+- continue treating canonical open issues as the primary wake signal
+- continue treating fork alignment plus supported `workflow_dispatch`
+  `template-smoke` results as the consumer proving signal
+- allow future agents arriving from compare-side pivot proof to start in the
+  canonical template repo and remain idle here if no eligible issue exists
 
 ## Labels
 


### PR DESCRIPTION
## Summary
- add canonical template root agent entrypoints
- document monitoring-only behavior when the canonical queue is empty
- clarify that consumer forks are proving rails and fork-local PR validation does not reopen work by itself

## Testing
- git diff --check
- verified `AGENT_HANDOFF.txt` stays short and decision-complete
- reviewed updated README and consumer proving rail contract for the supported wake conditions

Closes #13