### PR TITLE
Distribute vi-history capability from template (#16)

### DIFF
--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -36,6 +36,8 @@ jobs:
             repo_slug='template-smoke-sample' `
             github_owner='LabVIEW-Community-CI-CD' `
             default_branch='develop' `
+            comparevi_tools_consumer_pin='v0.6.3-tools.14' `
+            enable_vi_history_capability='yes' `
             license_holder='LabVIEW Community CI/CD' `
             copyright_year='2026'
           $generatedRoot = Join-Path $outputRoot 'template-smoke-sample'
@@ -49,10 +51,14 @@ jobs:
             '.gitignore',
             'docs/COMPAREVI_PLATFORM_INTEGRATION.md',
             'docs/CONSUMER_PROVING_RAIL.md',
+            'docs/VI_HISTORY_CAPABILITY.md',
             'tests/fixtures/comparevi/placeholder.vi',
+            '.github/comparevi/capabilities.json',
+            '.github/comparevi/lineage.json',
             '.github/ISSUE_TEMPLATE/config.yml',
             '.github/ISSUE_TEMPLATE/work-item.yml',
-            '.github/workflows/validate.yml'
+            '.github/workflows/validate.yml',
+            '.github/workflows/vi-history.yml'
           )
           foreach ($relativePath in $required) {
             $candidate = Join-Path $generatedRoot $relativePath
@@ -75,6 +81,37 @@ jobs:
           foreach ($snippet in $requiredSnippets) {
             if ($workflowContent -notlike "*$snippet*") {
               throw "Generated workflow is missing required snippet: $snippet"
+            }
+          }
+          $capabilityPath = Join-Path $generatedRoot '.github/comparevi/capabilities.json'
+          $capability = Get-Content -LiteralPath $capabilityPath -Raw | ConvertFrom-Json -AsHashtable
+          if (-not $capability.capabilities.viHistory.enabled) {
+            throw 'Rendered capability manifest should enable vi-history for template smoke.'
+          }
+          if ($capability.capabilities.viHistory.authoritativeConsumerPin -ne 'v0.6.3-tools.14') {
+            throw 'Rendered capability manifest did not preserve the CompareVI.Tools consumer pin.'
+          }
+          if ($capability.capabilities.viHistory.contractPaths.historyFacade -ne 'consumerContract.historyFacade') {
+            throw 'Rendered capability manifest is missing the distributed historyFacade contract path.'
+          }
+          $lineagePath = Join-Path $generatedRoot '.github/comparevi/lineage.json'
+          $lineage = Get-Content -LiteralPath $lineagePath -Raw | ConvertFrom-Json -AsHashtable
+          if ($lineage.branchRoles.producerLineage -ne 'upstream/develop') {
+            throw 'Rendered lineage manifest is missing the upstream/develop producer-lineage role.'
+          }
+          if ($lineage.branchRoles.consumerProving -ne 'downstream/develop') {
+            throw 'Rendered lineage manifest is missing the downstream/develop consumer-proving role.'
+          }
+          $historyWorkflowPath = Join-Path $generatedRoot '.github/workflows/vi-history.yml'
+          $historyWorkflowContent = Get-Content -LiteralPath $historyWorkflowPath -Raw
+          $historySnippets = @(
+            'default: v0.6.3-tools.14',
+            'CompareVI.Tools-$pin.zip',
+            '.github/comparevi/capabilities.json'
+          )
+          foreach ($snippet in $historySnippets) {
+            if ($historyWorkflowContent -notlike "*$snippet*") {
+              throw "Generated vi-history workflow is missing required snippet: $snippet"
             }
           }
           "generated_root=$generatedRoot" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This repository is intended to be used in two ways:
   - `.gitignore`
   - issue templates
   - consumer proving rail docs
+  - lineage and capability manifests for CompareVI integration
+  - an opt-in `vi-history` distribution scaffold pinned to CompareVI.Tools
   - hosted Linux + Windows consumer-proving workflow
 - a self-validation workflow that renders the template on both `ubuntu-latest`
   and `windows-latest`
@@ -39,6 +41,8 @@ cookiecutter https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate.
   project_name="LabVIEW Hosted CI Sample"
   repo_slug="labview-hosted-ci-sample"
   github_owner="LabVIEW-Community-CI-CD"
+  comparevi_tools_consumer_pin="v0.6.3-tools.14"
+  enable_vi_history_capability="yes"
 ```
 
 ## Canonical Operating Contract
@@ -63,6 +67,30 @@ Root repo agent entrypoints live in:
 Generated consumers still inherit their own `AGENTS.md`; the root files above
 only govern the canonical template repository itself.
 
+## VI History Capability Distribution
+
+This template now distributes `vi-history` as a lineage-aware CompareVI
+capability.
+
+The intended supply chain is:
+
+1. `compare-vi-cli-action` publishes the upstream CompareVI release bundle
+2. `LabviewGitHubCiTemplate` distributes the capability into generated repos
+3. generated repos consume the pinned bundle without copying compare internals
+
+Generated repositories now include:
+
+- `.github/comparevi/capabilities.json`
+- `.github/comparevi/lineage.json`
+- `.github/workflows/vi-history.yml`
+- `docs/VI_HISTORY_CAPABILITY.md`
+
+The distributed lineage contract uses these branch-role semantics:
+
+- `upstream/develop`: producer-lineage plane
+- `develop` or the generated repo's default branch: repo integration plane
+- `downstream/develop`: descendant consumer-proving plane
+
 ## Direction
 
 This repository is the mass-consumer cookiecutter surface for hosted GitHub CI
@@ -85,4 +113,6 @@ Current fork consumer proving guidance:
 
 See [docs/COMPAREVI_PLATFORM_INTEGRATION.md](docs/COMPAREVI_PLATFORM_INTEGRATION.md)
 for the intended boundary between generated consumers and the comparevi
-platform repos.
+platform repos, and
+[docs/VI_HISTORY_CAPABILITY_DISTRIBUTION.md](docs/VI_HISTORY_CAPABILITY_DISTRIBUTION.md)
+for the canonical distributor contract.

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,5 +4,10 @@
   "github_owner": "LabVIEW-Community-CI-CD",
   "default_branch": "develop",
   "license_holder": "LabVIEW Community CI/CD",
-  "copyright_year": "2026"
+  "copyright_year": "2026",
+  "comparevi_tools_consumer_pin": "v0.6.3-tools.14",
+  "enable_vi_history_capability": [
+    "yes",
+    "no"
+  ]
 }

--- a/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -8,7 +8,11 @@ CompareVI platform without copying platform ownership into the consumer repo.
 - `compare-vi-cli-action`
   - owns CompareVI runtime/tooling orchestration
   - owns hosted Linux and Windows execution surfaces
-  - owns release pins for CompareVI.Tools
+  - owns release pins and capability contracts for CompareVI.Tools
+- `LabviewGitHubCiTemplate`
+  - distributes CompareVI capabilities into generated repositories
+  - stamps lineage and capability manifests for descendants
+  - keeps the consumer surface lightweight and workflow-driven
 - `comparevi-history`
   - owns review bundle compilation and reviewer-facing rendering
   - owns pull-request diagnostics publication surfaces
@@ -16,6 +20,21 @@ CompareVI platform without copying platform ownership into the consumer repo.
   - own their repository-specific triggers, docs, and proving decisions
   - should stay hosted-first
   - should not fork platform runtime logic into local scripts by default
+
+## Branch-Role Semantics
+
+When a generated repository adopts lineage-aware CompareVI distribution, keep
+these branch roles explicit:
+
+- `upstream/develop`
+  - producer-lineage plane showing what arrived from the upstream producer
+- `develop` or the generated repo's default branch
+  - repository integration plane for local product work
+- `downstream/develop`
+  - descendant consumer-proving plane for future downstream reuse
+
+The template distributes these roles as metadata first. Repositories can
+materialize the extra branches when their own supply chain needs them.
 
 ## Reference Consumer
 
@@ -34,7 +53,9 @@ Generated consumers should:
 
 1. pin released platform artifacts instead of copying Docker/runtime helpers
 2. keep hosted Linux and hosted Windows as the authoritative proving surfaces
-3. add comparevi integration as an opt-in lane after the baseline hosted
+3. use the distributed lineage and capability manifests as the local source of
+   truth for `vi-history`
+4. add comparevi integration as an opt-in lane after the baseline hosted
    workflow is healthy
 
 This keeps the consumer template portable while still providing a clear path to

--- a/docs/CONSUMER_PROVING_RAIL.md
+++ b/docs/CONSUMER_PROVING_RAIL.md
@@ -44,6 +44,24 @@ standing-priority work.
   - remain the hosted-first proving target for downstream validation
   - should not inherit fork-only proving assumptions without explicit evidence
 
+## Lineage-Aware Descendants
+
+Generated consumers now receive a lightweight lineage contract alongside the
+hosted proving skeleton.
+
+That contract distinguishes:
+
+- `upstream/develop`
+  - upstream producer-lineage intake
+- `develop` or the generated repo's default branch
+  - integration and product authoring
+- `downstream/develop`
+  - future descendant consumer proving
+
+The template distributes those roles as machine-readable metadata so a
+generated repository can later become a producer for its own downstream
+consumers without copying compare's control plane.
+
 ## Monitoring Mode
 
 When the canonical template repo has no eligible open issue, monitoring-only is

--- a/docs/VI_HISTORY_CAPABILITY_DISTRIBUTION.md
+++ b/docs/VI_HISTORY_CAPABILITY_DISTRIBUTION.md
@@ -1,0 +1,59 @@
+# VI History Capability Distribution
+
+`LabviewGitHubCiTemplate` distributes `vi-history` as a lightweight capability
+pack sourced from `compare-vi-cli-action`.
+
+The canonical template remains a distributor, not a second owner of compare's
+runtime stack.
+
+## Roles
+
+- `compare-vi-cli-action`
+  - upstream producer for CompareVI.Tools and the `vi-history` capability
+- `LabviewGitHubCiTemplate`
+  - distributor that stamps capability and lineage metadata into generated repos
+- generated repositories
+  - consumers of the pinned release bundle and the distributed workflow/docs
+    scaffold
+
+## Distributed Surfaces
+
+Generated repositories receive:
+
+- `.github/comparevi/capabilities.json`
+- `.github/comparevi/lineage.json`
+- `.github/workflows/vi-history.yml`
+- `docs/VI_HISTORY_CAPABILITY.md`
+
+## Current Pin
+
+The default upstream consumer pin is `v0.6.3-tools.14`.
+
+That pin is intentionally stored in the template prompt surface so future
+template revisions can advance the pin without forcing downstream repos to copy
+compare internals.
+
+## Branch Roles
+
+The distributor contract defines three lineage planes:
+
+- `upstream/develop`
+  - upstream producer-lineage intake
+- `develop`
+  - canonical integration branch in the template repo
+- `downstream/develop`
+  - descendant consumer-proving plane
+
+Generated repositories inherit the same semantics, with their own selected
+default branch substituted for the integration plane where needed.
+
+## Design Boundary
+
+The distributed `vi-history` scaffold is intentionally lightweight:
+
+- release pin and capability metadata
+- manual hosted workflow scaffold
+- docs for consumers and descendants
+
+It does not copy compare's runtime governor, merge queue logic, or heavy local
+tooling surfaces into the generated repository.

--- a/{{ cookiecutter.repo_slug }}/.github/comparevi/capabilities.json
+++ b/{{ cookiecutter.repo_slug }}/.github/comparevi/capabilities.json
@@ -1,0 +1,26 @@
+{
+  "schema": "labview-template/comparevi-capabilities@v1",
+  "templateDistributorRepository": "LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate",
+  "templateDistributorBranch": "develop",
+  "capabilities": {
+    "viHistory": {
+      "enabled": {{ "true" if cookiecutter.enable_vi_history_capability == "yes" else "false" }},
+      "distributionRole": "template-distributor",
+      "upstreamProducerRepository": "LabVIEW-Community-CI-CD/compare-vi-cli-action",
+      "upstreamCapabilitySchema": "comparevi-tools/vi-history-capability@v1",
+      "distributionModel": "release-bundle",
+      "authoritativeConsumerPin": "{{ cookiecutter.comparevi_tools_consumer_pin }}",
+      "releaseAssetName": "CompareVI.Tools-{{ cookiecutter.comparevi_tools_consumer_pin }}.zip",
+      "releaseMetadataPath": "comparevi-tools-release.json",
+      "generatedWorkflowPath": ".github/workflows/vi-history.yml",
+      "integrationDocPath": "docs/VI_HISTORY_CAPABILITY.md",
+      "contractPaths": {
+        "historyFacade": "consumerContract.historyFacade",
+        "localRuntimeProfiles": "consumerContract.localRuntimeProfiles",
+        "localOperatorSession": "consumerContract.localOperatorSession",
+        "diagnosticsCommentRenderer": "consumerContract.diagnosticsCommentRenderer",
+        "hostedNiLinuxRunner": "consumerContract.hostedNiLinuxRunner"
+      }
+    }
+  }
+}

--- a/{{ cookiecutter.repo_slug }}/.github/comparevi/lineage.json
+++ b/{{ cookiecutter.repo_slug }}/.github/comparevi/lineage.json
@@ -1,0 +1,15 @@
+{
+  "schema": "labview-template/lineage-manifest@v1",
+  "templateRepository": "LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate",
+  "generatedFromTemplateBranch": "develop",
+  "generatedRepositoryOwner": "{{ cookiecutter.github_owner }}",
+  "generatedRepositorySlug": "{{ cookiecutter.repo_slug }}",
+  "upstreamProducerRepository": "LabVIEW-Community-CI-CD/compare-vi-cli-action",
+  "branchRoles": {
+    "producerLineage": "upstream/develop",
+    "integration": "{{ cookiecutter.default_branch }}",
+    "consumerProving": "downstream/develop"
+  },
+  "descendantCapabilityDistributionReady": {{ "true" if cookiecutter.enable_vi_history_capability == "yes" else "false" }},
+  "distributedCapabilityManifestPath": ".github/comparevi/capabilities.json"
+}

--- a/{{ cookiecutter.repo_slug }}/.github/workflows/vi-history.yml
+++ b/{{ cookiecutter.repo_slug }}/.github/workflows/vi-history.yml
@@ -1,0 +1,167 @@
+name: vi-history
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_path:
+        description: Path to a VI with meaningful history in this repository.
+        required: false
+        default: tests/fixtures/comparevi/placeholder.vi
+      base_ref:
+        description: Baseline ref for repository-specific VI-history adoption.
+        required: false
+        default: {{ cookiecutter.default_branch }}
+      head_ref:
+        description: Head ref for repository-specific VI-history adoption.
+        required: false
+        default: HEAD
+      comparevi_tools_consumer_pin:
+        description: Override the distributed CompareVI.Tools release pin.
+        required: false
+        default: {{ cookiecutter.comparevi_tools_consumer_pin }}
+
+jobs:
+  capability-bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Read distributed capability manifests
+        id: manifest
+        shell: pwsh
+        run: |
+          $capability = Get-Content -LiteralPath '.github/comparevi/capabilities.json' -Raw | ConvertFrom-Json -AsHashtable
+          $lineage = Get-Content -LiteralPath '.github/comparevi/lineage.json' -Raw | ConvertFrom-Json -AsHashtable
+          $viHistory = $capability.capabilities.viHistory
+          $enabled = [bool]$viHistory.enabled
+          $pin = '{% raw %}${{ inputs.comparevi_tools_consumer_pin }}{% endraw %}'
+          if ([string]::IsNullOrWhiteSpace($pin)) {
+            $pin = $viHistory.authoritativeConsumerPin
+          }
+          "enabled=$($enabled.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "pin=$pin" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "producer_lineage=$($lineage.branchRoles.producerLineage)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "consumer_proving=$($lineage.branchRoles.consumerProving)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          if ($env:GITHUB_STEP_SUMMARY) {
+            @(
+              '### Distributed VI History capability',
+              '',
+              ('- enabled: `{0}`' -f $enabled.ToString().ToLowerInvariant()),
+              ('- consumer_pin: `{0}`' -f $pin),
+              ('- producer_lineage: `{0}`' -f $lineage.branchRoles.producerLineage),
+              ('- integration_branch: `{0}`' -f $lineage.branchRoles.integration),
+              ('- consumer_proving: `{0}`' -f $lineage.branchRoles.consumerProving),
+              ('- target_path: `{0}`' -f '{% raw %}${{ inputs.target_path }}{% endraw %}'),
+              ('- base_ref: `{0}`' -f '{% raw %}${{ inputs.base_ref }}{% endraw %}'),
+              ('- head_ref: `{0}`' -f '{% raw %}${{ inputs.head_ref }}{% endraw %}')
+            ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+          }
+
+      - name: Download and verify CompareVI.Tools bundle
+        if: steps.manifest.outputs.enabled == 'true'
+        id: bundle
+        shell: pwsh
+        run: |
+          function Resolve-DottedPath {
+            param(
+              [Parameter(Mandatory = $true)]
+              [object]$InputObject,
+              [Parameter(Mandatory = $true)]
+              [string]$Path
+            )
+            $current = $InputObject
+            foreach ($segment in $Path.Split('.')) {
+              if ($current -is [System.Collections.IDictionary]) {
+                if (-not $current.Contains($segment)) {
+                  return $null
+                }
+                $current = $current[$segment]
+                continue
+              }
+              $property = $current.PSObject.Properties[$segment]
+              if (-not $property) {
+                return $null
+              }
+              $current = $property.Value
+            }
+            return $current
+          }
+
+          $pin = '{% raw %}${{ steps.manifest.outputs.pin }}{% endraw %}'
+          $assetName = "CompareVI.Tools-$pin.zip"
+          $downloadUri = "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/releases/download/$pin/$assetName"
+          $hashUri = "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/releases/download/$pin/SHA256SUMS.txt"
+          $workRoot = Join-Path $env:RUNNER_TEMP 'vi-history-capability'
+          New-Item -ItemType Directory -Path $workRoot -Force | Out-Null
+          $assetPath = Join-Path $workRoot $assetName
+          $hashPath = Join-Path $workRoot 'SHA256SUMS.txt'
+          Invoke-WebRequest -Uri $downloadUri -OutFile $assetPath
+          Invoke-WebRequest -Uri $hashUri -OutFile $hashPath
+
+          $expectedLine = Get-Content -LiteralPath $hashPath | Where-Object { $_ -match [regex]::Escape($assetName) } | Select-Object -First 1
+          if (-not $expectedLine) {
+            throw "Could not find checksum entry for $assetName"
+          }
+          $expectedHash = ($expectedLine -split '\s+')[0].ToLowerInvariant()
+          $actualHash = (Get-FileHash -LiteralPath $assetPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($expectedHash -ne $actualHash) {
+            throw "Checksum mismatch for $assetName"
+          }
+
+          $extractRoot = Join-Path $workRoot 'bundle'
+          Expand-Archive -LiteralPath $assetPath -DestinationPath $extractRoot -Force
+          $metadataPath = Join-Path $extractRoot "CompareVI.Tools-$pin\\comparevi-tools-release.json"
+          if (-not (Test-Path -LiteralPath $metadataPath)) {
+            throw "Missing comparevi-tools-release.json at $metadataPath"
+          }
+          $releaseManifest = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json -AsHashtable
+          $capability = Get-Content -LiteralPath '.github/comparevi/capabilities.json' -Raw | ConvertFrom-Json -AsHashtable
+          foreach ($contractPath in $capability.capabilities.viHistory.contractPaths.Values) {
+            if ($null -eq (Resolve-DottedPath -InputObject $releaseManifest -Path $contractPath)) {
+              throw "Missing contract path in release manifest: $contractPath"
+            }
+          }
+          $bundleCapability = Resolve-DottedPath -InputObject $releaseManifest -Path 'consumerContract.capabilities.viHistory'
+          $receiptRoot = Join-Path $PWD 'tests/results/vi-history'
+          New-Item -ItemType Directory -Path $receiptRoot -Force | Out-Null
+          $receiptPath = Join-Path $receiptRoot 'vi-history-bootstrap.json'
+          $receipt = [ordered]@{
+            schema = 'labview-template/vi-history-bootstrap@v1'
+            status = 'ready'
+            authoritativeConsumerPin = $pin
+            releaseAssetName = $assetName
+            releaseMetadataPath = 'comparevi-tools-release.json'
+            capabilityManifestPath = '.github/comparevi/capabilities.json'
+            lineageManifestPath = '.github/comparevi/lineage.json'
+            targetPath = '{% raw %}${{ inputs.target_path }}{% endraw %}'
+            baseRef = '{% raw %}${{ inputs.base_ref }}{% endraw %}'
+            headRef = '{% raw %}${{ inputs.head_ref }}{% endraw %}'
+            producerLineage = '{% raw %}${{ steps.manifest.outputs.producer_lineage }}{% endraw %}'
+            consumerProving = '{% raw %}${{ steps.manifest.outputs.consumer_proving }}{% endraw %}'
+            bundleCapabilityPresent = ($null -ne $bundleCapability)
+            requiredContractsResolved = $true
+          }
+          $receipt | ConvertTo-Json -Depth 10 | Out-File -LiteralPath $receiptPath -Encoding utf8
+          "receipt_path=$receiptPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Capability disabled summary
+        if: steps.manifest.outputs.enabled != 'true'
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_STEP_SUMMARY) {
+            @(
+              '### VI History capability disabled',
+              '',
+              '- status: `monitoring-only`',
+              '- no CompareVI.Tools bundle was downloaded'
+            ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+          }
+
+      - name: Upload vi-history bootstrap receipt
+        if: steps.manifest.outputs.enabled == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: vi-history-bootstrap
+          path: {% raw %}${{ steps.bundle.outputs.receipt_path }}{% endraw %}

--- a/{{ cookiecutter.repo_slug }}/AGENTS.md
+++ b/{{ cookiecutter.repo_slug }}/AGENTS.md
@@ -15,6 +15,10 @@ This repository was generated from `LabviewGitHubCiTemplate`.
 ## Branch Model
 
 - default integration branch: `{{ cookiecutter.default_branch }}`
+- `upstream/develop` represents upstream producer lineage when this repository
+  participates in a lineage-aware supply chain
+- `downstream/develop` represents descendant consumer proving when this
+  repository later distributes capabilities to downstream consumers
 - canonical repo owns template/product direction
 - forks are proving lanes and should avoid long-lived drift from upstream
 
@@ -22,4 +26,6 @@ This repository was generated from `LabviewGitHubCiTemplate`.
 
 - keep workflows portable across hosted Linux and hosted Windows
 - keep generated docs and issue templates in sync with the proving model
+- keep `.github/comparevi/capabilities.json` and `.github/comparevi/lineage.json`
+  aligned with any future capability adoption
 - prefer issue-driven work and visible acceptance criteria over ad hoc notes

--- a/{{ cookiecutter.repo_slug }}/README.md
+++ b/{{ cookiecutter.repo_slug }}/README.md
@@ -21,3 +21,22 @@ steps without first having to bootstrap a cross-OS GitHub Actions skeleton.
 If this repository later opts into CompareVI diagnostics, start with
 `docs/COMPAREVI_PLATFORM_INTEGRATION.md` and keep the platform/runtime boundary
 intact instead of copying platform-owned scripts into the consumer repo.
+
+## Distributed VI History Capability
+
+This generated repository includes a lightweight `vi-history` capability pack
+distributed by `LabviewGitHubCiTemplate`.
+
+- enabled: `{{ cookiecutter.enable_vi_history_capability }}`
+- CompareVI.Tools pin: `{{ cookiecutter.comparevi_tools_consumer_pin }}`
+- capability manifest: `.github/comparevi/capabilities.json`
+- lineage manifest: `.github/comparevi/lineage.json`
+- manual workflow scaffold: `.github/workflows/vi-history.yml`
+
+Branch-role semantics for future lineage-aware automation are:
+
+- `upstream/develop`: upstream producer lineage
+- `{{ cookiecutter.default_branch }}`: repository integration
+- `downstream/develop`: downstream consumer proving
+
+See `docs/VI_HISTORY_CAPABILITY.md` for the distributed consumer contract.

--- a/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -7,9 +7,37 @@ consumer, not as a second runtime owner.
 
 - `compare-vi-cli-action` owns runtime/tooling orchestration and released
   CompareVI.Tools assets
+- `LabviewGitHubCiTemplate` distributed the `vi-history` capability into this
+  repository as lightweight docs/workflow scaffolding
 - `comparevi-history` owns reviewer-facing history bundle/render surfaces
 - this repository should own only its consumer-specific workflow triggers,
   proving decisions, and documentation
+
+## Distributed Capability
+
+This repository inherits a distributed `vi-history` pack from the template.
+
+Use these local surfaces as the consumer source of truth:
+
+- `.github/comparevi/capabilities.json`
+- `.github/comparevi/lineage.json`
+- `.github/workflows/vi-history.yml`
+- `docs/VI_HISTORY_CAPABILITY.md`
+
+The distributed pin for CompareVI.Tools is
+`{{ cookiecutter.comparevi_tools_consumer_pin }}`.
+
+## Branch Roles
+
+When this repository adopts the full lineage model, treat these branches as the
+role map:
+
+- `upstream/develop`
+  - upstream producer-lineage intake
+- `{{ cookiecutter.default_branch }}`
+  - repository integration and product authoring
+- `downstream/develop`
+  - downstream consumer proving for future descendants
 
 ## Reference Consumer
 
@@ -24,5 +52,6 @@ platform without copying platform-owned runtime logic into the consumer repo.
 Treat comparevi integration as an opt-in lane:
 
 1. keep the baseline hosted Linux and hosted Windows consumer workflow healthy
-2. pin released comparevi artifacts
-3. add comparevi-specific proving only when the repository is ready for it
+2. keep the distributed capability and lineage manifests current
+3. pin released comparevi artifacts
+4. add comparevi-specific proving only when the repository is ready for it

--- a/{{ cookiecutter.repo_slug }}/docs/CONSUMER_PROVING_RAIL.md
+++ b/{{ cookiecutter.repo_slug }}/docs/CONSUMER_PROVING_RAIL.md
@@ -8,6 +8,17 @@ This generated repository assumes a hosted-first proving model.
 2. optional same-owner fork for shared proving
 3. optional personal fork for manual proving and remote worker routing
 
+## Lineage Roles
+
+This generated repository also carries a lightweight lineage contract.
+
+- `upstream/develop`
+  - upstream producer-lineage intake
+- `{{ cookiecutter.default_branch }}`
+  - repository integration and release direction
+- `downstream/develop`
+  - downstream consumer-proving plane for future descendants
+
 ## Labels
 
 - canonical repos: `standing-priority`

--- a/{{ cookiecutter.repo_slug }}/docs/VI_HISTORY_CAPABILITY.md
+++ b/{{ cookiecutter.repo_slug }}/docs/VI_HISTORY_CAPABILITY.md
@@ -1,0 +1,47 @@
+# VI History Capability
+
+This repository was generated with the template-distributed `vi-history`
+capability pack.
+
+## Current Contract
+
+- enabled: `{{ cookiecutter.enable_vi_history_capability }}`
+- CompareVI.Tools pin: `{{ cookiecutter.comparevi_tools_consumer_pin }}`
+- upstream producer: `LabVIEW-Community-CI-CD/compare-vi-cli-action`
+- distribution model: release bundle
+
+## Local Surfaces
+
+- capability manifest: `.github/comparevi/capabilities.json`
+- lineage manifest: `.github/comparevi/lineage.json`
+- manual workflow scaffold: `.github/workflows/vi-history.yml`
+
+## Branch Roles
+
+- `upstream/develop`
+  - upstream producer-lineage intake
+- `{{ cookiecutter.default_branch }}`
+  - repository integration
+- `downstream/develop`
+  - downstream consumer-proving plane
+
+## What The Workflow Does
+
+The distributed workflow is intentionally lightweight.
+
+It will:
+
+1. read the local capability and lineage manifests
+2. download the pinned CompareVI.Tools release bundle
+3. verify the bundle checksum and release metadata
+4. resolve the advertised consumer contract paths from the release metadata
+5. emit a bootstrap receipt for repository-specific adoption
+
+It does not copy compare's runtime governor or heavy local tooling into this
+repository.
+
+## Next Adoption Step
+
+When this repository is ready for repository-specific VI-history proving, bind
+`.github/workflows/vi-history.yml` to a real target VI path and the preferred
+baseline/head refs for your own workflow policy.


### PR DESCRIPTION
## Summary
- distribute `vi-history` as a template-managed CompareVI capability
- stamp lineage and capability manifests into generated repositories
- add a lightweight manual `vi-history` bootstrap workflow without importing compare's heavy control plane

## Changes
- add `comparevi_tools_consumer_pin` and `enable_vi_history_capability` to `cookiecutter.json`
- add template distributor docs for the producer/distributor/consumer model
- generate `.github/comparevi/capabilities.json` and `.github/comparevi/lineage.json`
- generate `docs/VI_HISTORY_CAPABILITY.md`
- generate `.github/workflows/vi-history.yml`
- extend `template-smoke` to validate the new scaffold and lineage contract

## Validation
- rendered the template locally with `enable_vi_history_capability=yes`
- rendered the template locally with `enable_vi_history_capability=no`
- verified the generated capability manifest, lineage manifest, and `vi-history` workflow in both modes
- `git diff --check`

Closes #16
