### PR TITLE
[comparevi]: add execution_profile selection for hosted/docker/mixed renders

### DIFF
--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -9,12 +9,13 @@ on:
 
 jobs:
   render:
-    name: render (${{ matrix.os }})
+    name: render (${{ matrix.os }}, ${{ matrix.execution_profile }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        execution_profile: [hosted, docker, mixed]
     steps:
       - uses: actions/checkout@v5
 
@@ -29,18 +30,20 @@ jobs:
         id: render
         shell: pwsh
         run: |
+          $executionProfile = '${{ matrix.execution_profile }}'
           $outputRoot = Join-Path $env:RUNNER_TEMP 'cookiecutter-render'
           New-Item -ItemType Directory -Path $outputRoot -Force | Out-Null
           cookiecutter $PWD --no-input --output-dir $outputRoot `
             project_name='Template Smoke Sample' `
-            repo_slug='template-smoke-sample' `
+            repo_slug=("template-smoke-{0}-sample" -f $executionProfile) `
             github_owner='LabVIEW-Community-CI-CD' `
             default_branch='develop' `
+            execution_profile=$executionProfile `
             comparevi_tools_consumer_pin='v0.6.3-tools.14' `
             enable_vi_history_capability='yes' `
             license_holder='LabVIEW Community CI/CD' `
             copyright_year='2026'
-          $generatedRoot = Join-Path $outputRoot 'template-smoke-sample'
+          $generatedRoot = Join-Path $outputRoot ("template-smoke-{0}-sample" -f $executionProfile)
           if (-not (Test-Path -LiteralPath $generatedRoot -PathType Container)) {
             throw "Rendered project was not created at $generatedRoot"
           }
@@ -64,6 +67,45 @@ jobs:
             $candidate = Join-Path $generatedRoot $relativePath
             if (-not (Test-Path -LiteralPath $candidate)) {
               throw "Missing rendered file: $relativePath"
+            }
+          }
+          $generatedReadmePath = Join-Path $generatedRoot 'README.md'
+          $generatedReadme = Get-Content -LiteralPath $generatedReadmePath -Raw
+          $profileSnippet = ('- execution profile: `{0}`' -f $executionProfile)
+          if ($generatedReadme -notlike "*$profileSnippet*") {
+            throw "Generated README is missing execution profile snippet: $profileSnippet"
+          }
+          $generatedPlatformDocPath = Join-Path $generatedRoot 'docs/COMPAREVI_PLATFORM_INTEGRATION.md'
+          $generatedPlatformDoc = Get-Content -LiteralPath $generatedPlatformDocPath -Raw
+          $generatedProvingDocPath = Join-Path $generatedRoot 'docs/CONSUMER_PROVING_RAIL.md'
+          $generatedProvingDoc = Get-Content -LiteralPath $generatedProvingDocPath -Raw
+          switch ($executionProfile) {
+            'hosted' {
+              if ($generatedPlatformDoc -notlike '*Docker-profile follow-up: not requested in this render*') {
+                throw 'Hosted render should declare that Docker follow-up is not requested.'
+              }
+              if ($generatedPlatformDoc -like '*Docker-profile follow-up: requested*') {
+                throw 'Hosted render should not emit Docker follow-up requested text.'
+              }
+              if ($generatedProvingDoc -notlike '*current contract: hosted-only generated surface*') {
+                throw 'Hosted render should declare the hosted-only proving contract.'
+              }
+            }
+            'docker' {
+              if ($generatedPlatformDoc -notlike '*Docker-profile follow-up: requested for a future template revision*') {
+                throw 'Docker render should declare future Docker follow-up intent.'
+              }
+              if ($generatedProvingDoc -notlike '*current contract: hosted surface plus recorded future Docker follow-up intent*') {
+                throw 'Docker render should declare hosted plus future Docker follow-up intent.'
+              }
+            }
+            'mixed' {
+              if ($generatedPlatformDoc -notlike '*Docker-profile follow-up: requested alongside the hosted surface*') {
+                throw 'Mixed render should declare mixed follow-up intent.'
+              }
+              if ($generatedProvingDoc -notlike '*current contract: hosted surface plus recorded mixed-mode follow-up intent*') {
+                throw 'Mixed render should declare hosted plus mixed-mode follow-up intent.'
+              }
             }
           }
           $workflowPath = Join-Path $generatedRoot '.github/workflows/validate.yml'
@@ -119,7 +161,7 @@ jobs:
       - name: Upload rendered sample
         uses: actions/upload-artifact@v4
         with:
-          name: template-smoke-${{ matrix.os }}
+          name: template-smoke-${{ matrix.os }}-${{ matrix.execution_profile }}
           path: ${{ steps.render.outputs.generated_root }}
 
   comparevi-consumer-smoke:

--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -33,17 +33,24 @@ jobs:
           $executionProfile = '${{ matrix.execution_profile }}'
           $outputRoot = Join-Path $env:RUNNER_TEMP 'cookiecutter-render'
           New-Item -ItemType Directory -Path $outputRoot -Force | Out-Null
-          cookiecutter $PWD --no-input --output-dir $outputRoot `
-            project_name='Template Smoke Sample' `
-            repo_slug=("template-smoke-{0}-sample" -f $executionProfile) `
-            github_owner='LabVIEW-Community-CI-CD' `
-            default_branch='develop' `
-            execution_profile=$executionProfile `
-            comparevi_tools_consumer_pin='v0.6.3-tools.14' `
-            enable_vi_history_capability='yes' `
-            license_holder='LabVIEW Community CI/CD' `
-            copyright_year='2026'
-          $generatedRoot = Join-Path $outputRoot ("template-smoke-{0}-sample" -f $executionProfile)
+          $repoSlug = "template-smoke-{0}-sample" -f $executionProfile
+          $cookiecutterArgs = @(
+            $PWD.Path
+            '--no-input'
+            '--output-dir'
+            $outputRoot
+            'project_name=Template Smoke Sample'
+            ('repo_slug={0}' -f $repoSlug)
+            'github_owner=LabVIEW-Community-CI-CD'
+            'default_branch=develop'
+            ('execution_profile={0}' -f $executionProfile)
+            'comparevi_tools_consumer_pin=v0.6.3-tools.14'
+            'enable_vi_history_capability=yes'
+            'license_holder=LabVIEW Community CI/CD'
+            'copyright_year=2026'
+          )
+          & cookiecutter @cookiecutterArgs
+          $generatedRoot = Join-Path $outputRoot $repoSlug
           if (-not (Test-Path -LiteralPath $generatedRoot -PathType Container)) {
             throw "Rendered project was not created at $generatedRoot"
           }

--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -79,7 +79,7 @@ jobs:
           $generatedReadmePath = Join-Path $generatedRoot 'README.md'
           $generatedReadme = Get-Content -LiteralPath $generatedReadmePath -Raw
           $profileSnippet = ('- execution profile: `{0}`' -f $executionProfile)
-          if ($generatedReadme -notlike "*$profileSnippet*") {
+          if (-not $generatedReadme.Contains($profileSnippet)) {
             throw "Generated README is missing execution profile snippet: $profileSnippet"
           }
           $generatedPlatformDocPath = Join-Path $generatedRoot 'docs/COMPAREVI_PLATFORM_INTEGRATION.md'

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This repository is intended to be used in two ways:
 ## What The First Revision Includes
 
 - BSD-3 license at the root and in generated consumers
-- `cookiecutter.json` prompts for repo identity and branch defaults
+- `cookiecutter.json` prompts for repo identity, branch defaults, and
+  execution-profile selection
 - a generated starter project with:
   - `AGENTS.md`
   - `README.md`
@@ -41,9 +42,21 @@ cookiecutter https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate.
   project_name="LabVIEW Hosted CI Sample"
   repo_slug="labview-hosted-ci-sample"
   github_owner="LabVIEW-Community-CI-CD"
+  execution_profile="hosted"
   comparevi_tools_consumer_pin="v0.6.3-tools.14"
   enable_vi_history_capability="yes"
 ```
+
+Supported `execution_profile` values:
+
+- `hosted`
+  - keep the generated repository hosted-first with no Docker-profile outputs
+- `docker`
+  - record Docker-profile intent for future follow-up slices while keeping the
+    current hosted proving contract intact in this revision
+- `mixed`
+  - keep the hosted surface and record future Docker-profile intent in the
+    generated consumer docs
 
 ## Canonical Operating Contract
 
@@ -66,6 +79,24 @@ Root repo agent entrypoints live in:
 
 Generated consumers still inherit their own `AGENTS.md`; the root files above
 only govern the canonical template repository itself.
+
+## Execution Profile Direction
+
+This template now accepts an `execution_profile` input with these supported
+values:
+
+- `hosted`
+- `docker`
+- `mixed`
+
+In this revision:
+
+- `hosted` remains the default
+- hosted Linux + hosted Windows stay the authoritative proving surfaces
+- Docker-specific contract and capability-manifest work stays in follow-up
+  implementation slices
+- `docker` and `mixed` currently record consumer intent without vendoring
+  compare runtime logic into the template
 
 ## VI History Capability Distribution
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,6 +5,11 @@
   "default_branch": "develop",
   "license_holder": "LabVIEW Community CI/CD",
   "copyright_year": "2026",
+  "execution_profile": [
+    "hosted",
+    "docker",
+    "mixed"
+  ],
   "comparevi_tools_consumer_pin": "v0.6.3-tools.14",
   "enable_vi_history_capability": [
     "yes",

--- a/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -55,7 +55,13 @@ Generated consumers should:
 2. keep hosted Linux and hosted Windows as the authoritative proving surfaces
 3. use the distributed lineage and capability manifests as the local source of
    truth for `vi-history`
-4. add comparevi integration as an opt-in lane after the baseline hosted
+4. treat `execution_profile` as the generated consumer's declared proving mode:
+   - `hosted`: no Docker-profile outputs in this template revision
+   - `docker`: future Docker follow-up requested while hosted proof remains the
+     current distributed surface
+   - `mixed`: future Docker follow-up requested while hosted proof remains
+     present
+5. add comparevi integration as an opt-in lane after the baseline hosted
    workflow is healthy
 
 This keeps the consumer template portable while still providing a clear path to

--- a/docs/CONSUMER_PROVING_RAIL.md
+++ b/docs/CONSUMER_PROVING_RAIL.md
@@ -34,6 +34,11 @@ standing-priority work.
 - canonical template repo
   - `template-smoke` on `push`, `pull_request`, and `workflow_dispatch` is the
     authoritative template-self-validation surface
+- generated execution-profile contract
+  - `hosted` is the default generated profile
+  - `docker` and `mixed` are accepted template inputs
+  - this revision keeps hosted proof authoritative while future Docker profile
+    slices land separately
 - consumer forks
   - keep fork `develop` aligned to canonical `develop`
   - treat `workflow_dispatch` on `template-smoke` from aligned `develop` as the

--- a/{{ cookiecutter.repo_slug }}/README.md
+++ b/{{ cookiecutter.repo_slug }}/README.md
@@ -7,6 +7,7 @@ Generated from `LabviewGitHubCiTemplate`.
 - owner: `{{ cookiecutter.github_owner }}`
 - slug: `{{ cookiecutter.repo_slug }}`
 - default branch: `{{ cookiecutter.default_branch }}`
+- execution profile: `{{ cookiecutter.execution_profile }}`
 
 ## Hosted Validation
 
@@ -15,6 +16,18 @@ in `.github/workflows/validate.yml`.
 
 The initial workflow is intentionally small so teams can add LabVIEW-specific
 steps without first having to bootstrap a cross-OS GitHub Actions skeleton.
+
+{% if cookiecutter.execution_profile == "hosted" -%}
+The selected execution profile is `hosted`, so this generated repository does
+not request Docker-profile outputs in this template revision.
+{% elif cookiecutter.execution_profile == "docker" -%}
+The selected execution profile is `docker`, which records future Docker-profile
+intent while this template revision still distributes the hosted proving
+surface.
+{% else -%}
+The selected execution profile is `mixed`, which keeps the hosted proving
+surface and records future Docker-profile intent for follow-up template slices.
+{% endif %}
 
 ## CompareVI Integration
 

--- a/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -27,6 +27,18 @@ Use these local surfaces as the consumer source of truth:
 The distributed pin for CompareVI.Tools is
 `{{ cookiecutter.comparevi_tools_consumer_pin }}`.
 
+## Execution Profile
+
+- selected profile: `{{ cookiecutter.execution_profile }}`
+{% if cookiecutter.execution_profile == "hosted" -%}
+- Docker-profile follow-up: not requested in this render
+{% elif cookiecutter.execution_profile == "docker" -%}
+- Docker-profile follow-up: requested for a future template revision
+{% else -%}
+- Docker-profile follow-up: requested alongside the hosted surface
+{% endif %}
+- hosted Linux + hosted Windows remain the current distributed proof surface
+
 ## Branch Roles
 
 When this repository adopts the full lineage model, treat these branches as the

--- a/{{ cookiecutter.repo_slug }}/docs/CONSUMER_PROVING_RAIL.md
+++ b/{{ cookiecutter.repo_slug }}/docs/CONSUMER_PROVING_RAIL.md
@@ -8,6 +8,18 @@ This generated repository assumes a hosted-first proving model.
 2. optional same-owner fork for shared proving
 3. optional personal fork for manual proving and remote worker routing
 
+## Execution Profile
+
+- selected profile: `{{ cookiecutter.execution_profile }}`
+{% if cookiecutter.execution_profile == "hosted" -%}
+- current contract: hosted-only generated surface
+{% elif cookiecutter.execution_profile == "docker" -%}
+- current contract: hosted surface plus recorded future Docker follow-up intent
+{% else -%}
+- current contract: hosted surface plus recorded mixed-mode follow-up intent
+{% endif %}
+- authoritative proof surface in this revision: hosted Linux + hosted Windows
+
 ## Lineage Roles
 
 This generated repository also carries a lightweight lineage contract.


### PR DESCRIPTION
## Summary

Implements `LabviewGitHubCiTemplate#19` by adding `execution_profile` selection to the template and proving the selection across `hosted`, `docker`, and `mixed` renders.

## What changed

- adds `execution_profile` to `cookiecutter.json`
- keeps `hosted` as the default
- updates canonical docs to explain current execution-profile behavior
- updates generated consumer docs to record the selected execution profile
- expands `template-smoke` to render and assert `hosted`, `docker`, and `mixed`

## Acceptance

- render succeeds for `hosted`, `docker`, and `mixed`
- hosted remains Docker-free in this revision
- current `vi-history` distribution behavior remains intact

## Validation

- local cookiecutter render matrix passed for `hosted`, `docker`, and `mixed`
- `git diff --check`

## Notes

This PR intentionally does not implement the blocked Docker capability-manifest rail from `#20`.
That work remains gated on the compare-side Producer contract prerequisite in LabVIEW-Community-CI-CD/compare-vi-cli-action#1940.

Closes #19