### PR TITLE
[comparevi]: render Docker capability contract in generated capabilities.json

### DIFF
--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -31,6 +31,7 @@ jobs:
         shell: pwsh
         run: |
           $executionProfile = '${{ matrix.execution_profile }}'
+          $compareViPin = if ($executionProfile -eq 'hosted') { 'v0.6.3-tools.14' } else { 'v0.6.4-rc.2' }
           $outputRoot = Join-Path $env:RUNNER_TEMP 'cookiecutter-render'
           New-Item -ItemType Directory -Path $outputRoot -Force | Out-Null
           $repoSlug = "template-smoke-{0}-sample" -f $executionProfile
@@ -44,7 +45,7 @@ jobs:
             'github_owner=LabVIEW-Community-CI-CD'
             'default_branch=develop'
             ('execution_profile={0}' -f $executionProfile)
-            'comparevi_tools_consumer_pin=v0.6.3-tools.14'
+            ('comparevi_tools_consumer_pin={0}' -f $compareViPin)
             'enable_vi_history_capability=yes'
             'license_holder=LabVIEW Community CI/CD'
             'copyright_year=2026'
@@ -81,6 +82,9 @@ jobs:
           $profileSnippet = ('- execution profile: `{0}`' -f $executionProfile)
           if (-not $generatedReadme.Contains($profileSnippet)) {
             throw "Generated README is missing execution profile snippet: $profileSnippet"
+          }
+          if ($generatedReadme -notlike "*CompareVI.Tools pin: ``$compareViPin``*") {
+            throw "Generated README is missing the selected CompareVI.Tools pin: $compareViPin"
           }
           $generatedPlatformDocPath = Join-Path $generatedRoot 'docs/COMPAREVI_PLATFORM_INTEGRATION.md'
           $generatedPlatformDoc = Get-Content -LiteralPath $generatedPlatformDocPath -Raw
@@ -137,11 +141,65 @@ jobs:
           if (-not $capability.capabilities.viHistory.enabled) {
             throw 'Rendered capability manifest should enable vi-history for template smoke.'
           }
-          if ($capability.capabilities.viHistory.authoritativeConsumerPin -ne 'v0.6.3-tools.14') {
+          if ($capability.capabilities.viHistory.authoritativeConsumerPin -ne $compareViPin) {
             throw 'Rendered capability manifest did not preserve the CompareVI.Tools consumer pin.'
           }
           if ($capability.capabilities.viHistory.contractPaths.historyFacade -ne 'consumerContract.historyFacade') {
             throw 'Rendered capability manifest is missing the distributed historyFacade contract path.'
+          }
+          $dockerCapability = $capability.capabilities.dockerProfile
+          switch ($executionProfile) {
+            'hosted' {
+              if ($null -ne $dockerCapability) {
+                throw 'Hosted render should not emit a dockerProfile capability entry.'
+              }
+            }
+            'docker' {
+              if ($null -eq $dockerCapability) {
+                throw 'Docker render should emit a dockerProfile capability entry.'
+              }
+              if (-not $dockerCapability.enabled) {
+                throw 'Docker render should enable the dockerProfile capability entry.'
+              }
+              if ($dockerCapability.upstreamCapabilitySchema -ne 'comparevi-tools/docker-profile-capability@v1') {
+                throw 'Docker render should record the published docker-profile capability schema.'
+              }
+              if ($dockerCapability.authoritativeImageContractSource -ne 'consumerContract.dockerImageContract') {
+                throw 'Docker render should record the authoritative image contract source.'
+              }
+              if ($dockerCapability.authoritativeConsumerPin -ne $compareViPin) {
+                throw 'Docker render should keep the CompareVI.Tools pin on the dockerProfile capability.'
+              }
+              if ($dockerCapability.requestedExecutionProfile -ne 'docker') {
+                throw 'Docker render should record docker as the requested execution profile.'
+              }
+              if ($dockerCapability.hostedSurfaceRetained) {
+                throw 'Docker render should not report hostedSurfaceRetained.'
+              }
+              if ($generatedPlatformDoc -notlike '*authoritative image-contract source: `consumerContract.dockerImageContract`*') {
+                throw 'Docker render should document the authoritative image contract source.'
+              }
+            }
+            'mixed' {
+              if ($null -eq $dockerCapability) {
+                throw 'Mixed render should emit a dockerProfile capability entry.'
+              }
+              if (-not $dockerCapability.enabled) {
+                throw 'Mixed render should enable the dockerProfile capability entry.'
+              }
+              if ($dockerCapability.authoritativeImageContractSource -ne 'consumerContract.dockerImageContract') {
+                throw 'Mixed render should record the authoritative image contract source.'
+              }
+              if ($dockerCapability.requestedExecutionProfile -ne 'mixed') {
+                throw 'Mixed render should record mixed as the requested execution profile.'
+              }
+              if (-not $dockerCapability.hostedSurfaceRetained) {
+                throw 'Mixed render should report hostedSurfaceRetained.'
+              }
+              if ($generatedPlatformDoc -notlike '*authoritative image-contract source: `consumerContract.dockerImageContract`*') {
+                throw 'Mixed render should document the authoritative image contract source.'
+              }
+            }
           }
           $lineagePath = Join-Path $generatedRoot '.github/comparevi/lineage.json'
           $lineage = Get-Content -LiteralPath $lineagePath -Raw | ConvertFrom-Json -AsHashtable
@@ -154,7 +212,7 @@ jobs:
           $historyWorkflowPath = Join-Path $generatedRoot '.github/workflows/vi-history.yml'
           $historyWorkflowContent = Get-Content -LiteralPath $historyWorkflowPath -Raw
           $historySnippets = @(
-            'default: v0.6.3-tools.14',
+            ('default: {0}' -f $compareViPin),
             'CompareVI.Tools-$pin.zip',
             '.github/comparevi/capabilities.json'
           )

--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -80,10 +80,11 @@ jobs:
           $generatedReadmePath = Join-Path $generatedRoot 'README.md'
           $generatedReadme = Get-Content -LiteralPath $generatedReadmePath -Raw
           $profileSnippet = ('- execution profile: `{0}`' -f $executionProfile)
+          $pinSnippet = ('CompareVI.Tools pin: `{0}`' -f $compareViPin)
           if (-not $generatedReadme.Contains($profileSnippet)) {
             throw "Generated README is missing execution profile snippet: $profileSnippet"
           }
-          if ($generatedReadme -notlike "*CompareVI.Tools pin: ``$compareViPin``*") {
+          if (-not $generatedReadme.Contains($pinSnippet)) {
             throw "Generated README is missing the selected CompareVI.Tools pin: $compareViPin"
           }
           $generatedPlatformDocPath = Join-Path $generatedRoot 'docs/COMPAREVI_PLATFORM_INTEGRATION.md'

--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -91,6 +91,7 @@ jobs:
           $generatedPlatformDoc = Get-Content -LiteralPath $generatedPlatformDocPath -Raw
           $generatedProvingDocPath = Join-Path $generatedRoot 'docs/CONSUMER_PROVING_RAIL.md'
           $generatedProvingDoc = Get-Content -LiteralPath $generatedProvingDocPath -Raw
+          $imageContractSnippet = 'authoritative image-contract source: `consumerContract.dockerImageContract`'
           switch ($executionProfile) {
             'hosted' {
               if ($generatedPlatformDoc -notlike '*Docker-profile follow-up: not requested in this render*') {
@@ -177,7 +178,7 @@ jobs:
               if ($dockerCapability.hostedSurfaceRetained) {
                 throw 'Docker render should not report hostedSurfaceRetained.'
               }
-              if ($generatedPlatformDoc -notlike '*authoritative image-contract source: `consumerContract.dockerImageContract`*') {
+              if (-not $generatedPlatformDoc.Contains($imageContractSnippet)) {
                 throw 'Docker render should document the authoritative image contract source.'
               }
             }
@@ -197,7 +198,7 @@ jobs:
               if (-not $dockerCapability.hostedSurfaceRetained) {
                 throw 'Mixed render should report hostedSurfaceRetained.'
               }
-              if ($generatedPlatformDoc -notlike '*authoritative image-contract source: `consumerContract.dockerImageContract`*') {
+              if (-not $generatedPlatformDoc.Contains($imageContractSnippet)) {
                 throw 'Mixed render should document the authoritative image contract source.'
               }
             }

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ In this revision:
 
 - `hosted` remains the default
 - hosted Linux + hosted Windows stay the authoritative proving surfaces
-- Docker-specific contract and capability-manifest work stays in follow-up
+- `docker` and `mixed` now stamp the Producer-published Docker capability
+  contract into `.github/comparevi/capabilities.json`
+- Docker workflow and lane-policy surfaces still stay in follow-up
   implementation slices
 - `docker` and `mixed` currently record consumer intent without vendoring
   compare runtime logic into the template
@@ -115,6 +117,10 @@ Generated repositories now include:
 - `.github/comparevi/lineage.json`
 - `.github/workflows/vi-history.yml`
 - `docs/VI_HISTORY_CAPABILITY.md`
+
+For `docker` and `mixed` renders, the capability manifest now also records the
+Producer-published Docker capability contract and
+`authoritativeImageContractSource = consumerContract.dockerImageContract`.
 
 The distributed lineage contract uses these branch-role semantics:
 

--- a/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -55,13 +55,19 @@ Generated consumers should:
 2. keep hosted Linux and hosted Windows as the authoritative proving surfaces
 3. use the distributed lineage and capability manifests as the local source of
    truth for `vi-history`
-4. treat `execution_profile` as the generated consumer's declared proving mode:
+4. for `docker` and `mixed`, read
+   `.github/comparevi/capabilities.json -> capabilities.dockerProfile` as the
+   template-distributed pointer to the Producer-owned image contract surface
+5. treat `execution_profile` as the generated consumer's declared proving mode:
    - `hosted`: no Docker-profile outputs in this template revision
-   - `docker`: future Docker follow-up requested while hosted proof remains the
-     current distributed surface
-   - `mixed`: future Docker follow-up requested while hosted proof remains
-     present
-5. add comparevi integration as an opt-in lane after the baseline hosted
+   - `docker`: Docker capability metadata is distributed and hosted proof
+     remains the current workflow surface
+   - `mixed`: Docker capability metadata is distributed while hosted proof
+     remains present
+6. resolve the actual Docker image contract from the pinned
+   `comparevi-tools-release.json` payload at
+   `consumerContract.dockerImageContract`
+7. add comparevi integration as an opt-in lane after the baseline hosted
    workflow is healthy
 
 This keeps the consumer template portable while still providing a clear path to

--- a/docs/VI_HISTORY_CAPABILITY_DISTRIBUTION.md
+++ b/docs/VI_HISTORY_CAPABILITY_DISTRIBUTION.md
@@ -25,6 +25,13 @@ Generated repositories receive:
 - `.github/workflows/vi-history.yml`
 - `docs/VI_HISTORY_CAPABILITY.md`
 
+For `docker` and `mixed` renders, `.github/comparevi/capabilities.json` also
+records the Producer-published Docker capability contract pointer:
+
+- capability id: `dockerProfile`
+- authoritative image-contract source: `consumerContract.dockerImageContract`
+- contract owner: `LabVIEW-Community-CI-CD/compare-vi-cli-action`
+
 ## Current Pin
 
 The default upstream consumer pin is `v0.6.3-tools.14`.
@@ -57,3 +64,8 @@ The distributed `vi-history` scaffold is intentionally lightweight:
 
 It does not copy compare's runtime governor, merge queue logic, or heavy local
 tooling surfaces into the generated repository.
+
+The Docker capability entry remains metadata-only in this slice.
+Generated repositories must still resolve the actual image contract from the
+pinned Producer release surface instead of vendoring compare implementation
+content.

--- a/{{ cookiecutter.repo_slug }}/.github/comparevi/capabilities.json
+++ b/{{ cookiecutter.repo_slug }}/.github/comparevi/capabilities.json
@@ -21,6 +21,21 @@
         "diagnosticsCommentRenderer": "consumerContract.diagnosticsCommentRenderer",
         "hostedNiLinuxRunner": "consumerContract.hostedNiLinuxRunner"
       }
+    }{% if cookiecutter.execution_profile != "hosted" %},
+    "dockerProfile": {
+      "enabled": true,
+      "distributionRole": "template-distributor",
+      "upstreamProducerRepository": "LabVIEW-Community-CI-CD/compare-vi-cli-action",
+      "upstreamCapabilitySchema": "comparevi-tools/docker-profile-capability@v1",
+      "distributionModel": "release-bundle",
+      "authoritativeConsumerPin": "{{ cookiecutter.comparevi_tools_consumer_pin }}",
+      "releaseAssetName": "CompareVI.Tools-{{ cookiecutter.comparevi_tools_consumer_pin }}.zip",
+      "releaseMetadataPath": "comparevi-tools-release.json",
+      "bundleImportPath": "tools/CompareVI.Tools/CompareVI.Tools.psd1",
+      "authoritativeImageContractSource": "consumerContract.dockerImageContract",
+      "requestedExecutionProfile": "{{ cookiecutter.execution_profile }}",
+      "hostedSurfaceRetained": {{ "true" if cookiecutter.execution_profile == "mixed" else "false" }}
     }
+    {% endif %}
   }
 }

--- a/{{ cookiecutter.repo_slug }}/README.md
+++ b/{{ cookiecutter.repo_slug }}/README.md
@@ -20,13 +20,20 @@ steps without first having to bootstrap a cross-OS GitHub Actions skeleton.
 {% if cookiecutter.execution_profile == "hosted" -%}
 The selected execution profile is `hosted`, so this generated repository does
 not request Docker-profile outputs in this template revision.
+Its `.github/comparevi/capabilities.json` manifest remains free of
+Docker-specific capability requirements.
 {% elif cookiecutter.execution_profile == "docker" -%}
 The selected execution profile is `docker`, which records future Docker-profile
 intent while this template revision still distributes the hosted proving
 surface.
+Its `.github/comparevi/capabilities.json` manifest records the Producer-published
+Docker capability contract and the authoritative image-contract source at
+`consumerContract.dockerImageContract`.
 {% else -%}
 The selected execution profile is `mixed`, which keeps the hosted proving
 surface and records future Docker-profile intent for follow-up template slices.
+Its `.github/comparevi/capabilities.json` manifest records the Producer-published
+Docker capability contract and keeps the hosted surface metadata alongside it.
 {% endif %}
 
 ## CompareVI Integration
@@ -53,3 +60,17 @@ Branch-role semantics for future lineage-aware automation are:
 - `downstream/develop`: downstream consumer proving
 
 See `docs/VI_HISTORY_CAPABILITY.md` for the distributed consumer contract.
+{% if cookiecutter.execution_profile != "hosted" %}
+
+## Docker Capability Contract
+
+This generated repository also records the CompareVI Producer-owned Docker
+capability contract in `.github/comparevi/capabilities.json`.
+
+- capability id: `dockerProfile`
+- authoritative image-contract source: `consumerContract.dockerImageContract`
+- Producer contract owner: `LabVIEW-Community-CI-CD/compare-vi-cli-action`
+
+Use a `comparevi_tools_consumer_pin` that publishes the Docker-profile
+capability contract, such as `v0.6.4-rc.2` or later.
+{% endif %}

--- a/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -32,12 +32,24 @@ The distributed pin for CompareVI.Tools is
 - selected profile: `{{ cookiecutter.execution_profile }}`
 {% if cookiecutter.execution_profile == "hosted" -%}
 - Docker-profile follow-up: not requested in this render
+- Docker capability manifest entry: omitted in this render
 {% elif cookiecutter.execution_profile == "docker" -%}
 - Docker-profile follow-up: requested for a future template revision
+- Docker capability manifest entry: `.github/comparevi/capabilities.json -> capabilities.dockerProfile`
+- authoritative image-contract source: `consumerContract.dockerImageContract`
 {% else -%}
 - Docker-profile follow-up: requested alongside the hosted surface
+- Docker capability manifest entry: `.github/comparevi/capabilities.json -> capabilities.dockerProfile`
+- authoritative image-contract source: `consumerContract.dockerImageContract`
 {% endif %}
 - hosted Linux + hosted Windows remain the current distributed proof surface
+
+{% if cookiecutter.execution_profile != "hosted" -%}
+The Docker capability entry is distributor metadata only.
+Resolve the actual image contract from the pinned Producer-published
+`comparevi-tools-release.json` payload instead of inventing repository-local
+image naming rules.
+{% endif %}
 
 ## Branch Roles
 


### PR DESCRIPTION
## Summary
- add a `dockerProfile` capability entry to generated `.github/comparevi/capabilities.json` for `docker` and `mixed` renders
- document the Producer-published docker contract and `authoritativeImageContractSource = consumerContract.dockerImageContract` in template and generated-consumer docs
- extend `template-smoke` assertions so hosted stays Docker-free while docker/mixed prove the published contract shape

## Validation
- local cookiecutter render matrix passed for `hosted`, `docker`, and `mixed`
- local render assertions passed for manifest shape, selected CompareVI.Tools pin, and docker contract documentation
- `git diff --check`

## Context
- unblocks `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate#20`
- depends on published Producer contract from `LabVIEW-Community-CI-CD/compare-vi-cli-action#1940`
- producer publication is now authoritative at `compare-vi-cli-action@v0.6.4-rc.2`
