### PR TITLE
feat(comparevi): consume producer-native vi-history capability (#18)

### DIFF
--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -31,7 +31,7 @@ jobs:
         shell: pwsh
         run: |
           $executionProfile = '${{ matrix.execution_profile }}'
-          $compareViPin = if ($executionProfile -eq 'hosted') { 'v0.6.3-tools.14' } else { 'v0.6.4-rc.2' }
+          $compareViPin = 'v0.6.4-rc.2'
           $outputRoot = Join-Path $env:RUNNER_TEMP 'cookiecutter-render'
           New-Item -ItemType Directory -Path $outputRoot -Force | Out-Null
           $repoSlug = "template-smoke-{0}-sample" -f $executionProfile
@@ -132,9 +132,15 @@ jobs:
             'Hosted Windows consumer lane',
             'vi_history_enabled',
             'release_asset_name',
+            'comparevi_ref',
             'consumerContract.capabilities.viHistory',
             'CompareVI.Tools-$pin.zip',
-            'Read and verify producer-native vi-history capability'
+            'Read and verify producer-native vi-history capability',
+            ('uses: LabVIEW-Community-CI-CD/compare-vi-cli-action@{0}' -f $compareViPin),
+            'Hosted Linux compare smoke',
+            'Hosted Windows compare smoke',
+            'shortCircuitedIdentical',
+            'diff'
           )
           foreach ($snippet in $requiredSnippets) {
             if ($workflowContent -notlike "*$snippet*") {
@@ -233,3 +239,41 @@ jobs:
         with:
           name: template-smoke-${{ matrix.os }}-${{ matrix.execution_profile }}
           path: ${{ steps.render.outputs.generated_root }}
+
+  comparevi-consumer-smoke:
+    name: comparevi-consumer-smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v5
+
+      - id: comparevi
+        name: CompareVI consumer smoke
+        uses: LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.4-rc.2
+        with:
+          base: tests/fixtures/comparevi/placeholder.vi
+          head: tests/fixtures/comparevi/placeholder.vi
+          fail-on-diff: 'false'
+
+      - name: Assert comparevi short-circuit
+        shell: pwsh
+        run: |
+          if ('${{ steps.comparevi.outputs.shortCircuitedIdentical }}' -ne 'true') {
+            throw 'Expected compare-vi consumer smoke to short-circuit identical inputs.'
+          }
+          if ('${{ steps.comparevi.outputs.diff }}' -ne 'false') {
+            throw 'Expected compare-vi consumer smoke to report no diff for identical inputs.'
+          }
+          if ($env:GITHUB_STEP_SUMMARY) {
+            @(
+              '### CompareVI consumer smoke',
+              '',
+              '- pinned_ref: `LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.4-rc.2`',
+              ('- runner_os: `{0}`' -f $env:RUNNER_OS),
+              ('- shortCircuitedIdentical: `{0}`' -f '${{ steps.comparevi.outputs.shortCircuitedIdentical }}'),
+              ('- diff: `{0}`' -f '${{ steps.comparevi.outputs.diff }}')
+            ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+          }

--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -130,8 +130,11 @@ jobs:
             '### Consumer proving plan',
             'Hosted Linux consumer lane',
             'Hosted Windows consumer lane',
-            'uses: LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3',
-            'shortCircuitedIdentical'
+            'vi_history_enabled',
+            'release_asset_name',
+            'consumerContract.capabilities.viHistory',
+            'CompareVI.Tools-$pin.zip',
+            'Read and verify producer-native vi-history capability'
           )
           foreach ($snippet in $requiredSnippets) {
             if ($workflowContent -notlike "*$snippet*") {
@@ -230,41 +233,3 @@ jobs:
         with:
           name: template-smoke-${{ matrix.os }}-${{ matrix.execution_profile }}
           path: ${{ steps.render.outputs.generated_root }}
-
-  comparevi-consumer-smoke:
-    name: comparevi-consumer-smoke (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@v5
-
-      - id: comparevi
-        name: CompareVI consumer smoke
-        uses: LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3
-        with:
-          base: tests/fixtures/comparevi/placeholder.vi
-          head: tests/fixtures/comparevi/placeholder.vi
-          fail-on-diff: 'false'
-
-      - name: Assert comparevi short-circuit
-        shell: pwsh
-        run: |
-          if ('${{ steps.comparevi.outputs.shortCircuitedIdentical }}' -ne 'true') {
-            throw 'Expected compare-vi consumer smoke to short-circuit identical inputs.'
-          }
-          if ('${{ steps.comparevi.outputs.diff }}' -ne 'false') {
-            throw 'Expected compare-vi consumer smoke to report no diff for identical inputs.'
-          }
-          if ($env:GITHUB_STEP_SUMMARY) {
-            @(
-              '### CompareVI consumer smoke',
-              '',
-              '- pinned_ref: `LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3`',
-              ('- runner_os: `{0}`' -f $env:RUNNER_OS),
-              ('- shortCircuitedIdentical: `{0}`' -f '${{ steps.comparevi.outputs.shortCircuitedIdentical }}'),
-              ('- diff: `{0}`' -f '${{ steps.comparevi.outputs.diff }}')
-            ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
-          }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cookiecutter https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate.
   repo_slug="labview-hosted-ci-sample"
   github_owner="LabVIEW-Community-CI-CD"
   execution_profile="hosted"
-  comparevi_tools_consumer_pin="v0.6.3-tools.14"
+  comparevi_tools_consumer_pin="v0.6.4-rc.2"
   enable_vi_history_capability="yes"
 ```
 
@@ -118,7 +118,11 @@ Generated repositories now include:
 - `.github/workflows/vi-history.yml`
 - `docs/VI_HISTORY_CAPABILITY.md`
 
-For `docker` and `mixed` renders, the capability manifest now also records the
+Generated `validate.yml` now fails closed unless the pinned CompareVI.Tools
+bundle exposes `consumerContract.capabilities.viHistory`, then runs the hosted
+consumer smoke against the same released producer-native pin.
+
+For `docker` and `mixed` renders, the capability manifest also records the
 Producer-published Docker capability contract and
 `authoritativeImageContractSource = consumerContract.dockerImageContract`.
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,7 +10,7 @@
     "docker",
     "mixed"
   ],
-  "comparevi_tools_consumer_pin": "v0.6.3-tools.14",
+  "comparevi_tools_consumer_pin": "v0.6.4-rc.2",
   "enable_vi_history_capability": [
     "yes",
     "no"

--- a/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -46,6 +46,7 @@ released CompareVI.Tools bundle through the distributed capability manifest:
 2. resolve `authoritativeConsumerPin`
 3. download `CompareVI.Tools-$pin.zip` from the released compare bundle
 4. fail closed unless the manifest exposes `consumerContract.capabilities.viHistory`
+5. run the hosted compare smoke against the same released producer-native pin
 
 ## Reference Consumer
 

--- a/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -2,6 +2,9 @@
 
 `LabviewGitHubCiTemplate` should help downstream consumers compose with the
 CompareVI platform without copying platform ownership into the consumer repo.
+The generated consumer validation workflow now resolves the authoritative
+CompareVI.Tools pin from the local capability manifest and fails closed unless
+the released bundle exposes `consumerContract.capabilities.viHistory`.
 
 ## Ownership Boundary
 
@@ -36,6 +39,14 @@ these branch roles explicit:
 The template distributes these roles as metadata first. Repositories can
 materialize the extra branches when their own supply chain needs them.
 
+Generated `validate.yml` should stay lightweight while still consuming the
+released CompareVI.Tools bundle through the distributed capability manifest:
+
+1. read `.github/comparevi/capabilities.json`
+2. resolve `authoritativeConsumerPin`
+3. download `CompareVI.Tools-$pin.zip` from the released compare bundle
+4. fail closed unless the manifest exposes `consumerContract.capabilities.viHistory`
+
 ## Reference Consumer
 
 Use `LabVIEW-Community-CI-CD/labview-icon-editor-demo` on `develop` as the
@@ -54,7 +65,7 @@ Generated consumers should:
 1. pin released platform artifacts instead of copying Docker/runtime helpers
 2. keep hosted Linux and hosted Windows as the authoritative proving surfaces
 3. use the distributed lineage and capability manifests as the local source of
-   truth for `vi-history`
+   truth for `vi-history` and generated validation
 4. for `docker` and `mixed`, read
    `.github/comparevi/capabilities.json -> capabilities.dockerProfile` as the
    template-distributed pointer to the Producer-owned image contract surface

--- a/docs/VI_HISTORY_CAPABILITY_DISTRIBUTION.md
+++ b/docs/VI_HISTORY_CAPABILITY_DISTRIBUTION.md
@@ -34,7 +34,7 @@ records the Producer-published Docker capability contract pointer:
 
 ## Current Pin
 
-The default upstream consumer pin is `v0.6.3-tools.14`.
+The default upstream consumer pin is `v0.6.4-rc.2`.
 
 That pin is intentionally stored in the template prompt surface so future
 template revisions can advance the pin without forcing downstream repos to copy
@@ -65,7 +65,10 @@ The distributed `vi-history` scaffold is intentionally lightweight:
 It does not copy compare's runtime governor, merge queue logic, or heavy local
 tooling surfaces into the generated repository.
 
-The Docker capability entry remains metadata-only in this slice.
-Generated repositories must still resolve the actual image contract from the
-pinned Producer release surface instead of vendoring compare implementation
-content.
+Generated `validate.yml` now consumes the Producer-native `vi-history`
+capability contract directly from the pinned CompareVI.Tools bundle before it
+runs the hosted compare smoke.
+
+The Docker capability entry remains metadata-only in this slice. Generated
+repositories must still resolve the actual image contract from the pinned
+Producer release surface instead of vendoring compare implementation content.

--- a/{{ cookiecutter.repo_slug }}/.github/workflows/validate.yml
+++ b/{{ cookiecutter.repo_slug }}/.github/workflows/validate.yml
@@ -22,76 +22,290 @@ jobs:
       - name: Consumer proving plan
         shell: pwsh
         run: |
-          $lines = @(
-            '### Consumer proving plan',
-            '',
-            ('- event: `{0}`' -f '{% raw %}${{ github.event_name }}{% endraw %}'),
-            ('- ref: `{0}`' -f '{% raw %}${{ github.ref }}{% endraw %}'),
-            ('- proving_reason: `{0}`' -f '{% raw %}${{ inputs.proving_reason || ''manual'' }}{% endraw %}'),
-            '- hosted_lanes: `ubuntu-latest`, `windows-latest`'
-          )
-          $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+          $capability = Get-Content -LiteralPath '.github/comparevi/capabilities.json' -Raw | ConvertFrom-Json -AsHashtable
+          $lineage = Get-Content -LiteralPath '.github/comparevi/lineage.json' -Raw | ConvertFrom-Json -AsHashtable
+          $viHistory = $capability.capabilities.viHistory
+          $enabled = [bool]$viHistory.enabled
+          $pin = $viHistory.authoritativeConsumerPin
+          $releaseAssetName = $viHistory.releaseAssetName
+          if ([string]::IsNullOrWhiteSpace($releaseAssetName)) {
+            $releaseAssetName = "CompareVI.Tools-$pin.zip"
+          }
+          if ($env:GITHUB_STEP_SUMMARY) {
+            @(
+              '### Consumer proving plan',
+              '',
+              ('- event: `{0}`' -f '{% raw %}${{ github.event_name }}{% endraw %}'),
+              ('- ref: `{0}`' -f '{% raw %}${{ github.ref }}{% endraw %}'),
+              ('- proving_reason: `{0}`' -f '{% raw %}${{ inputs.proving_reason || ''manual'' }}{% endraw %}'),
+              ('- vi_history_enabled: `{0}`' -f $enabled.ToString().ToLowerInvariant()),
+              ('- consumer_pin: `{0}`' -f $pin),
+              ('- release_asset_name: `{0}`' -f $releaseAssetName),
+              ('- consumer_contract: `consumerContract.capabilities.viHistory`'),
+              ('- producer_lineage: `{0}`' -f $lineage.branchRoles.producerLineage),
+              ('- consumer_proving: `{0}`' -f $lineage.branchRoles.consumerProving),
+              ('- hosted_lanes: `ubuntu-latest`, `windows-latest`')
+            ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+          }
 
   hosted-linux:
-    needs: consumer-plan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - id: comparevi
-        name: CompareVI consumer smoke
-        uses: LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3
-        with:
-          base: tests/fixtures/comparevi/placeholder.vi
-          head: tests/fixtures/comparevi/placeholder.vi
-          fail-on-diff: 'false'
-      - name: Hosted Linux consumer lane
+      - name: Read and verify producer-native vi-history capability
+        id: bundle
         shell: pwsh
         run: |
-          if ('{% raw %}${{ steps.comparevi.outputs.shortCircuitedIdentical }}{% endraw %}' -ne 'true') {
-            throw 'Expected compare-vi consumer smoke to short-circuit identical inputs on hosted Linux.'
+          function Resolve-DottedPath {
+            param(
+              [Parameter(Mandatory = $true)]
+              [object]$InputObject,
+              [Parameter(Mandatory = $true)]
+              [string]$Path
+            )
+            $current = $InputObject
+            foreach ($segment in $Path.Split('.')) {
+              if ($current -is [System.Collections.IDictionary]) {
+                if (-not $current.Contains($segment)) {
+                  return $null
+                }
+                $current = $current[$segment]
+                continue
+              }
+              $property = $current.PSObject.Properties[$segment]
+              if (-not $property) {
+                return $null
+              }
+              $current = $property.Value
+            }
+            return $current
           }
-          Write-Host 'Hosted Linux consumer lane is ready for project-specific LabVIEW automation.'
-          Write-Host ('Repository: {0}/{1}' -f '{% raw %}${{ github.repository_owner }}{% endraw %}', '{% raw %}${{ github.event.repository.name }}{% endraw %}')
-          Write-Host ('Ref: {0}' -f '{% raw %}${{ github.ref }}{% endraw %}')
+
+          $capability = Get-Content -LiteralPath '.github/comparevi/capabilities.json' -Raw | ConvertFrom-Json -AsHashtable
+          $lineage = Get-Content -LiteralPath '.github/comparevi/lineage.json' -Raw | ConvertFrom-Json -AsHashtable
+          $viHistory = $capability.capabilities.viHistory
+          $enabled = [bool]$viHistory.enabled
+          if (-not $enabled) {
+            Write-Host 'VI history capability disabled; consumer validation is monitoring-only.'
+            if ($env:GITHUB_STEP_SUMMARY) {
+              @(
+                '### Hosted Linux consumer lane',
+                '',
+                '- status: `monitoring-only`',
+                ('- runner_os: `{0}`' -f $env:RUNNER_OS)
+              ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+            }
+            exit 0
+          }
+
+          $pin = $viHistory.authoritativeConsumerPin
+          if ([string]::IsNullOrWhiteSpace($pin)) {
+            throw 'Missing authoritative consumer pin for the distributed vi-history capability.'
+          }
+
+          $assetName = $viHistory.releaseAssetName
+          if ([string]::IsNullOrWhiteSpace($assetName)) {
+            $assetName = "CompareVI.Tools-$pin.zip"
+          }
+
+          $downloadUri = "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/releases/download/$pin/$assetName"
+          $hashUri = "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/releases/download/$pin/SHA256SUMS.txt"
+          $workRoot = Join-Path $env:RUNNER_TEMP 'vi-history-capability'
+          New-Item -ItemType Directory -Path $workRoot -Force | Out-Null
+          $assetPath = Join-Path $workRoot $assetName
+          $hashPath = Join-Path $workRoot 'SHA256SUMS.txt'
+          Invoke-WebRequest -Uri $downloadUri -OutFile $assetPath
+          Invoke-WebRequest -Uri $hashUri -OutFile $hashPath
+
+          $expectedLine = Get-Content -LiteralPath $hashPath | Where-Object { $_ -match [regex]::Escape($assetName) } | Select-Object -First 1
+          if (-not $expectedLine) {
+            throw "Could not find checksum entry for $assetName"
+          }
+          $expectedHash = ($expectedLine -split '\s+')[0].ToLowerInvariant()
+          $actualHash = (Get-FileHash -LiteralPath $assetPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($expectedHash -ne $actualHash) {
+            throw "Checksum mismatch for $assetName"
+          }
+
+          $extractRoot = Join-Path $workRoot 'bundle'
+          Expand-Archive -LiteralPath $assetPath -DestinationPath $extractRoot -Force
+          $metadataPath = Join-Path $extractRoot "CompareVI.Tools-$pin\\comparevi-tools-release.json"
+          if (-not (Test-Path -LiteralPath $metadataPath)) {
+            throw "Missing comparevi-tools-release.json at $metadataPath"
+          }
+          $releaseManifest = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json -AsHashtable
+          foreach ($contractPath in $viHistory.contractPaths.Values) {
+            if ($null -eq (Resolve-DottedPath -InputObject $releaseManifest -Path $contractPath)) {
+              throw "Missing contract path in release manifest: $contractPath"
+            }
+          }
+          $bundleCapability = Resolve-DottedPath -InputObject $releaseManifest -Path 'consumerContract.capabilities.viHistory'
+          if ($null -eq $bundleCapability) {
+            throw 'Producer-native vi-history capability is missing from the CompareVI.Tools release manifest.'
+          }
+          $receiptRoot = Join-Path $PWD 'tests/results/vi-history'
+          New-Item -ItemType Directory -Path $receiptRoot -Force | Out-Null
+          $receiptPath = Join-Path $receiptRoot 'validate-vi-history.json'
+          [ordered]@{
+            schema = 'labview-template/validate-vi-history@v1'
+            status = 'ready'
+            runner = $env:RUNNER_OS
+            authoritativeConsumerPin = $pin
+            releaseAssetName = $assetName
+            releaseMetadataPath = 'comparevi-tools-release.json'
+            capabilityManifestPath = '.github/comparevi/capabilities.json'
+            lineageManifestPath = '.github/comparevi/lineage.json'
+            producerLineage = $lineage.branchRoles.producerLineage
+            consumerProving = $lineage.branchRoles.consumerProving
+            bundleCapabilityPresent = $true
+            requiredContractsResolved = $true
+          } | ConvertTo-Json -Depth 10 | Out-File -LiteralPath $receiptPath -Encoding utf8
+          "receipt_path=$receiptPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           if ($env:GITHUB_STEP_SUMMARY) {
             @(
               '### Hosted Linux consumer lane',
               '',
               '- status: `ready`',
               ('- runner_os: `{0}`' -f $env:RUNNER_OS),
-              '- comparevi_ref: `LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3`',
-              ('- shortCircuitedIdentical: `{0}`' -f '{% raw %}${{ steps.comparevi.outputs.shortCircuitedIdentical }}{% endraw %}')
+              ('- comparevi_tools_consumer_pin: `{0}`' -f $pin),
+              ('- release_asset_name: `{0}`' -f $assetName),
+              ('- producer_native_contract: `consumerContract.capabilities.viHistory`')
             ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           }
 
+      - name: Upload vi-history validation receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: vi-history-validation-linux
+          path: {% raw %}${{ steps.bundle.outputs.receipt_path }}{% endraw %}
+
   hosted-windows:
-    needs: consumer-plan
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
-      - id: comparevi
-        name: CompareVI consumer smoke
-        uses: LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3
-        with:
-          base: tests/fixtures/comparevi/placeholder.vi
-          head: tests/fixtures/comparevi/placeholder.vi
-          fail-on-diff: 'false'
-      - name: Hosted Windows consumer lane
-        shell: powershell
+      - name: Read and verify producer-native vi-history capability
+        id: bundle
+        shell: pwsh
         run: |
-          if ('{% raw %}${{ steps.comparevi.outputs.shortCircuitedIdentical }}{% endraw %}' -ne 'true') {
-            throw 'Expected compare-vi consumer smoke to short-circuit identical inputs on hosted Windows.'
+          function Resolve-DottedPath {
+            param(
+              [Parameter(Mandatory = $true)]
+              [object]$InputObject,
+              [Parameter(Mandatory = $true)]
+              [string]$Path
+            )
+            $current = $InputObject
+            foreach ($segment in $Path.Split('.')) {
+              if ($current -is [System.Collections.IDictionary]) {
+                if (-not $current.Contains($segment)) {
+                  return $null
+                }
+                $current = $current[$segment]
+                continue
+              }
+              $property = $current.PSObject.Properties[$segment]
+              if (-not $property) {
+                return $null
+              }
+              $current = $property.Value
+            }
+            return $current
           }
-          Write-Host 'Hosted Windows consumer lane is ready for project-specific LabVIEW automation.'
-          Write-Host ('Repository: {0}/{1}' -f '{% raw %}${{ github.repository_owner }}{% endraw %}', '{% raw %}${{ github.event.repository.name }}{% endraw %}')
-          Write-Host ('Ref: {0}' -f '{% raw %}${{ github.ref }}{% endraw %}')
+
+          $capability = Get-Content -LiteralPath '.github/comparevi/capabilities.json' -Raw | ConvertFrom-Json -AsHashtable
+          $lineage = Get-Content -LiteralPath '.github/comparevi/lineage.json' -Raw | ConvertFrom-Json -AsHashtable
+          $viHistory = $capability.capabilities.viHistory
+          $enabled = [bool]$viHistory.enabled
+          if (-not $enabled) {
+            Write-Host 'VI history capability disabled; consumer validation is monitoring-only.'
+            if ($env:GITHUB_STEP_SUMMARY) {
+              @(
+                '### Hosted Windows consumer lane',
+                '',
+                '- status: `monitoring-only`',
+                ('- runner_os: `{0}`' -f $env:RUNNER_OS)
+              ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+            }
+            exit 0
+          }
+
+          $pin = $viHistory.authoritativeConsumerPin
+          if ([string]::IsNullOrWhiteSpace($pin)) {
+            throw 'Missing authoritative consumer pin for the distributed vi-history capability.'
+          }
+
+          $assetName = $viHistory.releaseAssetName
+          if ([string]::IsNullOrWhiteSpace($assetName)) {
+            $assetName = "CompareVI.Tools-$pin.zip"
+          }
+
+          $downloadUri = "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/releases/download/$pin/$assetName"
+          $hashUri = "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/releases/download/$pin/SHA256SUMS.txt"
+          $workRoot = Join-Path $env:RUNNER_TEMP 'vi-history-capability'
+          New-Item -ItemType Directory -Path $workRoot -Force | Out-Null
+          $assetPath = Join-Path $workRoot $assetName
+          $hashPath = Join-Path $workRoot 'SHA256SUMS.txt'
+          Invoke-WebRequest -Uri $downloadUri -OutFile $assetPath
+          Invoke-WebRequest -Uri $hashUri -OutFile $hashPath
+
+          $expectedLine = Get-Content -LiteralPath $hashPath | Where-Object { $_ -match [regex]::Escape($assetName) } | Select-Object -First 1
+          if (-not $expectedLine) {
+            throw "Could not find checksum entry for $assetName"
+          }
+          $expectedHash = ($expectedLine -split '\s+')[0].ToLowerInvariant()
+          $actualHash = (Get-FileHash -LiteralPath $assetPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($expectedHash -ne $actualHash) {
+            throw "Checksum mismatch for $assetName"
+          }
+
+          $extractRoot = Join-Path $workRoot 'bundle'
+          Expand-Archive -LiteralPath $assetPath -DestinationPath $extractRoot -Force
+          $metadataPath = Join-Path $extractRoot "CompareVI.Tools-$pin\comparevi-tools-release.json"
+          if (-not (Test-Path -LiteralPath $metadataPath)) {
+            throw "Missing comparevi-tools-release.json at $metadataPath"
+          }
+          $releaseManifest = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json -AsHashtable
+          foreach ($contractPath in $viHistory.contractPaths.Values) {
+            if ($null -eq (Resolve-DottedPath -InputObject $releaseManifest -Path $contractPath)) {
+              throw "Missing contract path in release manifest: $contractPath"
+            }
+          }
+          $bundleCapability = Resolve-DottedPath -InputObject $releaseManifest -Path 'consumerContract.capabilities.viHistory'
+          if ($null -eq $bundleCapability) {
+            throw 'Producer-native vi-history capability is missing from the CompareVI.Tools release manifest.'
+          }
+          $receiptRoot = Join-Path $PWD 'tests/results/vi-history'
+          New-Item -ItemType Directory -Path $receiptRoot -Force | Out-Null
+          $receiptPath = Join-Path $receiptRoot 'validate-vi-history.json'
+          [ordered]@{
+            schema = 'labview-template/validate-vi-history@v1'
+            status = 'ready'
+            runner = $env:RUNNER_OS
+            authoritativeConsumerPin = $pin
+            releaseAssetName = $assetName
+            releaseMetadataPath = 'comparevi-tools-release.json'
+            capabilityManifestPath = '.github/comparevi/capabilities.json'
+            lineageManifestPath = '.github/comparevi/lineage.json'
+            producerLineage = $lineage.branchRoles.producerLineage
+            consumerProving = $lineage.branchRoles.consumerProving
+            bundleCapabilityPresent = $true
+            requiredContractsResolved = $true
+          } | ConvertTo-Json -Depth 10 | Out-File -LiteralPath $receiptPath -Encoding utf8
+          "receipt_path=$receiptPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           if ($env:GITHUB_STEP_SUMMARY) {
             @(
               '### Hosted Windows consumer lane',
               '',
               '- status: `ready`',
               ('- runner_os: `{0}`' -f $env:RUNNER_OS),
-              '- comparevi_ref: `LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3`',
-              ('- shortCircuitedIdentical: `{0}`' -f '{% raw %}${{ steps.comparevi.outputs.shortCircuitedIdentical }}{% endraw %}')
+              ('- comparevi_tools_consumer_pin: `{0}`' -f $pin),
+              ('- release_asset_name: `{0}`' -f $assetName),
+              ('- producer_native_contract: `consumerContract.capabilities.viHistory`')
             ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           }
+
+      - name: Upload vi-history validation receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: vi-history-validation-windows
+          path: {% raw %}${{ steps.bundle.outputs.receipt_path }}{% endraw %}

--- a/{{ cookiecutter.repo_slug }}/.github/workflows/validate.yml
+++ b/{{ cookiecutter.repo_slug }}/.github/workflows/validate.yml
@@ -19,6 +19,7 @@ jobs:
   consumer-plan:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v5
       - name: Consumer proving plan
         shell: pwsh
         run: |
@@ -41,6 +42,7 @@ jobs:
               ('- vi_history_enabled: `{0}`' -f $enabled.ToString().ToLowerInvariant()),
               ('- consumer_pin: `{0}`' -f $pin),
               ('- release_asset_name: `{0}`' -f $releaseAssetName),
+              ('- comparevi_ref: `LabVIEW-Community-CI-CD/compare-vi-cli-action@{0}`' -f $pin),
               ('- consumer_contract: `consumerContract.capabilities.viHistory`'),
               ('- producer_lineage: `{0}`' -f $lineage.branchRoles.producerLineage),
               ('- consumer_proving: `{0}`' -f $lineage.branchRoles.consumerProving),
@@ -49,6 +51,7 @@ jobs:
           }
 
   hosted-linux:
+    needs: consumer-plan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -85,8 +88,26 @@ jobs:
           $lineage = Get-Content -LiteralPath '.github/comparevi/lineage.json' -Raw | ConvertFrom-Json -AsHashtable
           $viHistory = $capability.capabilities.viHistory
           $enabled = [bool]$viHistory.enabled
+          $receiptRoot = Join-Path $PWD 'tests/results/vi-history'
+          New-Item -ItemType Directory -Path $receiptRoot -Force | Out-Null
+          $receiptPath = Join-Path $receiptRoot 'validate-vi-history.json'
           if (-not $enabled) {
             Write-Host 'VI history capability disabled; consumer validation is monitoring-only.'
+            [ordered]@{
+              schema = 'labview-template/validate-vi-history@v1'
+              status = 'monitoring-only'
+              runner = $env:RUNNER_OS
+              authoritativeConsumerPin = $null
+              releaseAssetName = $null
+              releaseMetadataPath = 'comparevi-tools-release.json'
+              capabilityManifestPath = '.github/comparevi/capabilities.json'
+              lineageManifestPath = '.github/comparevi/lineage.json'
+              producerLineage = $lineage.branchRoles.producerLineage
+              consumerProving = $lineage.branchRoles.consumerProving
+              bundleCapabilityPresent = $false
+              requiredContractsResolved = $false
+            } | ConvertTo-Json -Depth 10 | Out-File -LiteralPath $receiptPath -Encoding utf8
+            "receipt_path=$receiptPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
             if ($env:GITHUB_STEP_SUMMARY) {
               @(
                 '### Hosted Linux consumer lane',
@@ -143,9 +164,6 @@ jobs:
           if ($null -eq $bundleCapability) {
             throw 'Producer-native vi-history capability is missing from the CompareVI.Tools release manifest.'
           }
-          $receiptRoot = Join-Path $PWD 'tests/results/vi-history'
-          New-Item -ItemType Directory -Path $receiptRoot -Force | Out-Null
-          $receiptPath = Join-Path $receiptRoot 'validate-vi-history.json'
           [ordered]@{
             schema = 'labview-template/validate-vi-history@v1'
             status = 'ready'
@@ -173,6 +191,34 @@ jobs:
             ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           }
 
+      - id: comparevi
+        name: CompareVI consumer smoke
+        uses: LabVIEW-Community-CI-CD/compare-vi-cli-action@{{ cookiecutter.comparevi_tools_consumer_pin }}
+        with:
+          base: tests/fixtures/comparevi/placeholder.vi
+          head: tests/fixtures/comparevi/placeholder.vi
+          fail-on-diff: 'false'
+
+      - name: Assert hosted Linux compare smoke
+        shell: pwsh
+        run: |
+          if ('{% raw %}${{ steps.comparevi.outputs.shortCircuitedIdentical }}{% endraw %}' -ne 'true') {
+            throw 'Expected compare-vi consumer smoke to short-circuit identical inputs on hosted Linux.'
+          }
+          if ('{% raw %}${{ steps.comparevi.outputs.diff }}{% endraw %}' -ne 'false') {
+            throw 'Expected compare-vi consumer smoke to report no diff for identical inputs on hosted Linux.'
+          }
+          if ($env:GITHUB_STEP_SUMMARY) {
+            @(
+              '### Hosted Linux compare smoke',
+              '',
+              '- status: `ready`',
+              ('- comparevi_ref: `LabVIEW-Community-CI-CD/compare-vi-cli-action@{0}`' -f '{{ cookiecutter.comparevi_tools_consumer_pin }}'),
+              ('- shortCircuitedIdentical: `{0}`' -f '{% raw %}${{ steps.comparevi.outputs.shortCircuitedIdentical }}{% endraw %}'),
+              ('- diff: `{0}`' -f '{% raw %}${{ steps.comparevi.outputs.diff }}{% endraw %}')
+            ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+          }
+
       - name: Upload vi-history validation receipt
         uses: actions/upload-artifact@v4
         with:
@@ -180,6 +226,7 @@ jobs:
           path: {% raw %}${{ steps.bundle.outputs.receipt_path }}{% endraw %}
 
   hosted-windows:
+    needs: consumer-plan
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
@@ -216,8 +263,26 @@ jobs:
           $lineage = Get-Content -LiteralPath '.github/comparevi/lineage.json' -Raw | ConvertFrom-Json -AsHashtable
           $viHistory = $capability.capabilities.viHistory
           $enabled = [bool]$viHistory.enabled
+          $receiptRoot = Join-Path $PWD 'tests/results/vi-history'
+          New-Item -ItemType Directory -Path $receiptRoot -Force | Out-Null
+          $receiptPath = Join-Path $receiptRoot 'validate-vi-history.json'
           if (-not $enabled) {
             Write-Host 'VI history capability disabled; consumer validation is monitoring-only.'
+            [ordered]@{
+              schema = 'labview-template/validate-vi-history@v1'
+              status = 'monitoring-only'
+              runner = $env:RUNNER_OS
+              authoritativeConsumerPin = $null
+              releaseAssetName = $null
+              releaseMetadataPath = 'comparevi-tools-release.json'
+              capabilityManifestPath = '.github/comparevi/capabilities.json'
+              lineageManifestPath = '.github/comparevi/lineage.json'
+              producerLineage = $lineage.branchRoles.producerLineage
+              consumerProving = $lineage.branchRoles.consumerProving
+              bundleCapabilityPresent = $false
+              requiredContractsResolved = $false
+            } | ConvertTo-Json -Depth 10 | Out-File -LiteralPath $receiptPath -Encoding utf8
+            "receipt_path=$receiptPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
             if ($env:GITHUB_STEP_SUMMARY) {
               @(
                 '### Hosted Windows consumer lane',
@@ -274,9 +339,6 @@ jobs:
           if ($null -eq $bundleCapability) {
             throw 'Producer-native vi-history capability is missing from the CompareVI.Tools release manifest.'
           }
-          $receiptRoot = Join-Path $PWD 'tests/results/vi-history'
-          New-Item -ItemType Directory -Path $receiptRoot -Force | Out-Null
-          $receiptPath = Join-Path $receiptRoot 'validate-vi-history.json'
           [ordered]@{
             schema = 'labview-template/validate-vi-history@v1'
             status = 'ready'
@@ -301,6 +363,34 @@ jobs:
               ('- comparevi_tools_consumer_pin: `{0}`' -f $pin),
               ('- release_asset_name: `{0}`' -f $assetName),
               ('- producer_native_contract: `consumerContract.capabilities.viHistory`')
+            ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+          }
+
+      - id: comparevi
+        name: CompareVI consumer smoke
+        uses: LabVIEW-Community-CI-CD/compare-vi-cli-action@{{ cookiecutter.comparevi_tools_consumer_pin }}
+        with:
+          base: tests/fixtures/comparevi/placeholder.vi
+          head: tests/fixtures/comparevi/placeholder.vi
+          fail-on-diff: 'false'
+
+      - name: Assert hosted Windows compare smoke
+        shell: pwsh
+        run: |
+          if ('{% raw %}${{ steps.comparevi.outputs.shortCircuitedIdentical }}{% endraw %}' -ne 'true') {
+            throw 'Expected compare-vi consumer smoke to short-circuit identical inputs on hosted Windows.'
+          }
+          if ('{% raw %}${{ steps.comparevi.outputs.diff }}{% endraw %}' -ne 'false') {
+            throw 'Expected compare-vi consumer smoke to report no diff for identical inputs on hosted Windows.'
+          }
+          if ($env:GITHUB_STEP_SUMMARY) {
+            @(
+              '### Hosted Windows compare smoke',
+              '',
+              '- status: `ready`',
+              ('- comparevi_ref: `LabVIEW-Community-CI-CD/compare-vi-cli-action@{0}`' -f '{{ cookiecutter.comparevi_tools_consumer_pin }}'),
+              ('- shortCircuitedIdentical: `{0}`' -f '{% raw %}${{ steps.comparevi.outputs.shortCircuitedIdentical }}{% endraw %}'),
+              ('- diff: `{0}`' -f '{% raw %}${{ steps.comparevi.outputs.diff }}{% endraw %}')
             ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           }
 

--- a/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -37,6 +37,7 @@ released CompareVI.Tools bundle through the distributed capability manifest:
 2. resolve `authoritativeConsumerPin`
 3. download `CompareVI.Tools-$pin.zip` from the released compare bundle
 4. fail closed unless the manifest exposes `consumerContract.capabilities.viHistory`
+5. run the hosted compare smoke against the same released producer-native pin
 
 ## Execution Profile
 

--- a/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -1,7 +1,10 @@
 # CompareVI Platform Integration
 
 This generated repository should compose with the comparevi platform as a
-consumer, not as a second runtime owner.
+consumer, not as a second runtime owner. The generated validation workflow now
+resolves the authoritative CompareVI.Tools pin from the local capability
+manifest and fails closed unless the released bundle exposes
+`consumerContract.capabilities.viHistory`.
 
 ## Boundary
 
@@ -26,6 +29,14 @@ Use these local surfaces as the consumer source of truth:
 
 The distributed pin for CompareVI.Tools is
 `{{ cookiecutter.comparevi_tools_consumer_pin }}`.
+
+Generated `validate.yml` should stay lightweight while still consuming the
+released CompareVI.Tools bundle through the distributed capability manifest:
+
+1. read `.github/comparevi/capabilities.json`
+2. resolve `authoritativeConsumerPin`
+3. download `CompareVI.Tools-$pin.zip` from the released compare bundle
+4. fail closed unless the manifest exposes `consumerContract.capabilities.viHistory`
 
 ## Execution Profile
 


### PR DESCRIPTION
## Summary

- consume the published producer-native `vi-history` capability contract from the released CompareVI.Tools bundle in generated `validate.yml`
- restore hosted compare smoke on the same producer-native pin after the fail-closed capability check
- advance the default template consumer pin to `v0.6.4-rc.2` and update template docs/smoke coverage accordingly

## Validation

- local cookiecutter render matrix passed for `hosted`, `docker`, and `mixed`
- verified generated `validate.yml` now combines producer-native bundle verification with hosted compare smoke
- `git diff --check`

Closes #18.
