### PR TITLE
[comparevi]: render Docker workflow and documentation set for docker and mixed profiles (#25)

### DIFF
--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -71,6 +71,11 @@ jobs:
             '.github/workflows/validate.yml',
             '.github/workflows/vi-history.yml'
           )
+          $dockerRequired = @(
+            'docs/DOCKER_PROFILE.md',
+            '.github/comparevi/docker-lane-policy.json',
+            '.github/workflows/docker-profile.yml'
+          )
           foreach ($relativePath in $required) {
             $candidate = Join-Path $generatedRoot $relativePath
             if (-not (Test-Path -LiteralPath $candidate)) {
@@ -92,8 +97,17 @@ jobs:
           $generatedProvingDocPath = Join-Path $generatedRoot 'docs/CONSUMER_PROVING_RAIL.md'
           $generatedProvingDoc = Get-Content -LiteralPath $generatedProvingDocPath -Raw
           $imageContractSnippet = 'authoritative image-contract source: `consumerContract.dockerImageContract`'
+          $dockerDocPath = Join-Path $generatedRoot 'docs/DOCKER_PROFILE.md'
+          $dockerPolicyPath = Join-Path $generatedRoot '.github/comparevi/docker-lane-policy.json'
+          $dockerWorkflowPath = Join-Path $generatedRoot '.github/workflows/docker-profile.yml'
           switch ($executionProfile) {
             'hosted' {
+              foreach ($relativePath in $dockerRequired) {
+                $candidate = Join-Path $generatedRoot $relativePath
+                if (Test-Path -LiteralPath $candidate) {
+                  throw "Hosted render should not emit Docker scaffold file: $relativePath"
+                }
+              }
               if ($generatedPlatformDoc -notlike '*Docker-profile follow-up: not requested in this render*') {
                 throw 'Hosted render should declare that Docker follow-up is not requested.'
               }
@@ -105,19 +119,31 @@ jobs:
               }
             }
             'docker' {
-              if ($generatedPlatformDoc -notlike '*Docker-profile follow-up: requested for a future template revision*') {
-                throw 'Docker render should declare future Docker follow-up intent.'
+              foreach ($relativePath in $dockerRequired) {
+                $candidate = Join-Path $generatedRoot $relativePath
+                if (-not (Test-Path -LiteralPath $candidate)) {
+                  throw "Docker render should emit Docker scaffold file: $relativePath"
+                }
               }
-              if ($generatedProvingDoc -notlike '*current contract: hosted surface plus recorded future Docker follow-up intent*') {
-                throw 'Docker render should declare hosted plus future Docker follow-up intent.'
+              if ($generatedPlatformDoc -notlike '*Docker workflow scaffold: `.github/workflows/docker-profile.yml`*') {
+                throw 'Docker render should declare the generated Docker workflow scaffold.'
+              }
+              if ($generatedProvingDoc -notlike '*current contract: hosted proof plus distributed Docker workflow/documentation scaffold*') {
+                throw 'Docker render should declare hosted proof plus distributed Docker scaffold.'
               }
             }
             'mixed' {
-              if ($generatedPlatformDoc -notlike '*Docker-profile follow-up: requested alongside the hosted surface*') {
-                throw 'Mixed render should declare mixed follow-up intent.'
+              foreach ($relativePath in $dockerRequired) {
+                $candidate = Join-Path $generatedRoot $relativePath
+                if (-not (Test-Path -LiteralPath $candidate)) {
+                  throw "Mixed render should emit Docker scaffold file: $relativePath"
+                }
               }
-              if ($generatedProvingDoc -notlike '*current contract: hosted surface plus recorded mixed-mode follow-up intent*') {
-                throw 'Mixed render should declare hosted plus mixed-mode follow-up intent.'
+              if ($generatedPlatformDoc -notlike '*Docker workflow scaffold: `.github/workflows/docker-profile.yml`*') {
+                throw 'Mixed render should declare the generated Docker workflow scaffold.'
+              }
+              if ($generatedProvingDoc -notlike '*current contract: hosted proof plus distributed Docker workflow/documentation scaffold and retained hosted surface*') {
+                throw 'Mixed render should declare hosted proof plus distributed Docker scaffold and retained hosted surface.'
               }
             }
           }
@@ -190,6 +216,26 @@ jobs:
               if (-not $generatedPlatformDoc.Contains($imageContractSnippet)) {
                 throw 'Docker render should document the authoritative image contract source.'
               }
+              $dockerDoc = Get-Content -LiteralPath $dockerDocPath -Raw
+              if ($dockerDoc -notlike '*workflow scaffold: `.github/workflows/docker-profile.yml`*') {
+                throw 'Docker render should document the generated Docker workflow scaffold.'
+              }
+              $dockerPolicy = Get-Content -LiteralPath $dockerPolicyPath -Raw | ConvertFrom-Json -AsHashtable
+              if ($dockerPolicy.requestedExecutionProfile -ne 'docker') {
+                throw 'Docker lane policy should record docker as the requested execution profile.'
+              }
+              if ($dockerPolicy.hostedSurfaceRetained) {
+                throw 'Docker lane policy should not report hostedSurfaceRetained.'
+              }
+              if ($dockerPolicy.authoritativeImageContractSource -ne 'consumerContract.dockerImageContract') {
+                throw 'Docker lane policy should record the authoritative image contract source.'
+              }
+              $dockerWorkflow = Get-Content -LiteralPath $dockerWorkflowPath -Raw
+              foreach ($snippet in @('### Docker consumer lane', '.github/comparevi/docker-lane-policy.json', 'consumerContract.dockerImageContract', 'runtime ownership remains producer-owned')) {
+                if ($dockerWorkflow -notlike "*$snippet*") {
+                  throw "Docker workflow scaffold is missing required snippet: $snippet"
+                }
+              }
             }
             'mixed' {
               if ($null -eq $dockerCapability) {
@@ -209,6 +255,26 @@ jobs:
               }
               if (-not $generatedPlatformDoc.Contains($imageContractSnippet)) {
                 throw 'Mixed render should document the authoritative image contract source.'
+              }
+              $dockerDoc = Get-Content -LiteralPath $dockerDocPath -Raw
+              if ($dockerDoc -notlike '*hosted surface retained: `true`*') {
+                throw 'Mixed render should document hosted surface retention.'
+              }
+              $dockerPolicy = Get-Content -LiteralPath $dockerPolicyPath -Raw | ConvertFrom-Json -AsHashtable
+              if ($dockerPolicy.requestedExecutionProfile -ne 'mixed') {
+                throw 'Mixed lane policy should record mixed as the requested execution profile.'
+              }
+              if (-not $dockerPolicy.hostedSurfaceRetained) {
+                throw 'Mixed lane policy should report hostedSurfaceRetained.'
+              }
+              if ($dockerPolicy.authoritativeImageContractSource -ne 'consumerContract.dockerImageContract') {
+                throw 'Mixed lane policy should record the authoritative image contract source.'
+              }
+              $dockerWorkflow = Get-Content -LiteralPath $dockerWorkflowPath -Raw
+              foreach ($snippet in @('### Docker consumer lane', '.github/comparevi/docker-lane-policy.json', 'consumerContract.dockerImageContract', 'runtime ownership remains producer-owned')) {
+                if ($dockerWorkflow -notlike "*$snippet*") {
+                  throw "Mixed Docker workflow scaffold is missing required snippet: $snippet"
+                }
               }
             }
           }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository is intended to be used in two ways:
   - consumer proving rail docs
   - lineage and capability manifests for CompareVI integration
   - an opt-in `vi-history` distribution scaffold pinned to CompareVI.Tools
+  - a Docker workflow/documentation scaffold for `docker` and `mixed` renders
   - hosted Linux + Windows consumer-proving workflow
 - a self-validation workflow that renders the template on both `ubuntu-latest`
   and `windows-latest`
@@ -52,11 +53,11 @@ Supported `execution_profile` values:
 - `hosted`
   - keep the generated repository hosted-first with no Docker-profile outputs
 - `docker`
-  - record Docker-profile intent for future follow-up slices while keeping the
-    current hosted proving contract intact in this revision
+  - render the Docker workflow/documentation scaffold while keeping the current
+    hosted proving contract intact in this revision
 - `mixed`
-  - keep the hosted surface and record future Docker-profile intent in the
-    generated consumer docs
+  - keep the hosted surface and also render the Docker
+    workflow/documentation scaffold
 
 ## Canonical Operating Contract
 
@@ -95,8 +96,10 @@ In this revision:
 - hosted Linux + hosted Windows stay the authoritative proving surfaces
 - `docker` and `mixed` now stamp the Producer-published Docker capability
   contract into `.github/comparevi/capabilities.json`
-- Docker workflow and lane-policy surfaces still stay in follow-up
-  implementation slices
+- `docker` and `mixed` now also render:
+  - `.github/workflows/docker-profile.yml`
+  - `.github/comparevi/docker-lane-policy.json`
+  - `docs/DOCKER_PROFILE.md`
 - `docker` and `mixed` currently record consumer intent without vendoring
   compare runtime logic into the template
 
@@ -125,6 +128,12 @@ consumer smoke against the same released producer-native pin.
 For `docker` and `mixed` renders, the capability manifest also records the
 Producer-published Docker capability contract and
 `authoritativeImageContractSource = consumerContract.dockerImageContract`.
+
+Those renders now also distribute a consumer-facing Docker scaffold:
+
+- `.github/workflows/docker-profile.yml`
+- `.github/comparevi/docker-lane-policy.json`
+- `docs/DOCKER_PROFILE.md`
 
 The distributed lineage contract uses these branch-role semantics:
 

--- a/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -72,14 +72,19 @@ Generated consumers should:
    template-distributed pointer to the Producer-owned image contract surface
 5. treat `execution_profile` as the generated consumer's declared proving mode:
    - `hosted`: no Docker-profile outputs in this template revision
-   - `docker`: Docker capability metadata is distributed and hosted proof
-     remains the current workflow surface
-   - `mixed`: Docker capability metadata is distributed while hosted proof
-     remains present
+   - `docker`: Docker capability metadata, lane policy, workflow scaffold, and
+     consumer documentation are distributed while hosted proof remains the
+     current authoritative workflow surface
+   - `mixed`: the hosted surface remains present while the Docker capability
+     metadata, lane policy, workflow scaffold, and consumer documentation are
+     also distributed
 6. resolve the actual Docker image contract from the pinned
    `comparevi-tools-release.json` payload at
    `consumerContract.dockerImageContract`
-7. add comparevi integration as an opt-in lane after the baseline hosted
+7. treat `.github/comparevi/docker-lane-policy.json` and
+   `.github/workflows/docker-profile.yml` as consumer-facing scaffolds, not as
+   local ownership of CompareVI runtime logic
+8. add comparevi integration as an opt-in lane after the baseline hosted
    workflow is healthy
 
 This keeps the consumer template portable while still providing a clear path to

--- a/docs/CONSUMER_PROVING_RAIL.md
+++ b/docs/CONSUMER_PROVING_RAIL.md
@@ -37,8 +37,9 @@ standing-priority work.
 - generated execution-profile contract
   - `hosted` is the default generated profile
   - `docker` and `mixed` are accepted template inputs
-  - this revision keeps hosted proof authoritative while future Docker profile
-    slices land separately
+  - this revision keeps hosted proof authoritative while `docker` and `mixed`
+    now distribute a Docker workflow/documentation scaffold for downstream
+    adoption
 - consumer forks
   - keep fork `develop` aligned to canonical `develop`
   - treat `workflow_dispatch` on `template-smoke` from aligned `develop` as the

--- a/docs/VI_HISTORY_CAPABILITY_DISTRIBUTION.md
+++ b/docs/VI_HISTORY_CAPABILITY_DISTRIBUTION.md
@@ -69,6 +69,7 @@ Generated `validate.yml` now consumes the Producer-native `vi-history`
 capability contract directly from the pinned CompareVI.Tools bundle before it
 runs the hosted compare smoke.
 
-The Docker capability entry remains metadata-only in this slice. Generated
-repositories must still resolve the actual image contract from the pinned
-Producer release surface instead of vendoring compare implementation content.
+The Docker capability entry now ships with a lane policy file, a manual Docker
+workflow scaffold, and a consumer-facing Docker doc. Generated repositories
+must still resolve the actual image contract from the pinned Producer release
+surface instead of vendoring compare implementation content.

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+EXECUTION_PROFILE = "{{ cookiecutter.execution_profile }}"
+
+
+def remove_if_present(relative_path: str) -> None:
+    path = Path(relative_path)
+    if path.exists():
+        path.unlink()
+
+
+if EXECUTION_PROFILE == "hosted":
+    for relative_path in (
+        ".github/comparevi/docker-lane-policy.json",
+        ".github/workflows/docker-profile.yml",
+        "docs/DOCKER_PROFILE.md",
+    ):
+        remove_if_present(relative_path)

--- a/{{ cookiecutter.repo_slug }}/.github/comparevi/docker-lane-policy.json
+++ b/{{ cookiecutter.repo_slug }}/.github/comparevi/docker-lane-policy.json
@@ -1,0 +1,13 @@
+{
+  "schema": "labview-template/docker-lane-policy@v1",
+  "distributionRole": "template-distributor",
+  "upstreamProducerRepository": "LabVIEW-Community-CI-CD/compare-vi-cli-action",
+  "authoritativeConsumerPin": "{{ cookiecutter.comparevi_tools_consumer_pin }}",
+  "requestedExecutionProfile": "{{ cookiecutter.execution_profile }}",
+  "hostedSurfaceRetained": {{ "true" if cookiecutter.execution_profile == "mixed" else "false" }},
+  "authoritativeImageContractSource": "consumerContract.dockerImageContract",
+  "notes": [
+    "Use this file together with .github/comparevi/capabilities.json as the local Docker scaffold contract.",
+    "Hosted Linux and hosted Windows remain authoritative until the consumer explicitly adopts Docker-backed proof."
+  ]
+}

--- a/{{ cookiecutter.repo_slug }}/.github/workflows/docker-profile.yml
+++ b/{{ cookiecutter.repo_slug }}/.github/workflows/docker-profile.yml
@@ -1,0 +1,40 @@
+name: docker-profile
+
+on:
+  workflow_dispatch:
+    inputs:
+      docker_reason:
+        description: Why this Docker consumer lane is being dispatched.
+        required: false
+        default: manual
+
+jobs:
+  docker-consumer-lane:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Read Docker scaffold contract
+        shell: pwsh
+        run: |
+          $capability = Get-Content -LiteralPath '.github/comparevi/capabilities.json' -Raw | ConvertFrom-Json -AsHashtable
+          $policy = Get-Content -LiteralPath '.github/comparevi/docker-lane-policy.json' -Raw | ConvertFrom-Json -AsHashtable
+          $dockerProfile = $capability.capabilities.dockerProfile
+          if ($null -eq $dockerProfile) {
+            throw 'Missing dockerProfile capability in the generated capability manifest.'
+          }
+          if ($policy.authoritativeImageContractSource -ne 'consumerContract.dockerImageContract') {
+            throw 'Unexpected authoritative image-contract source in the Docker lane policy.'
+          }
+          if ($env:GITHUB_STEP_SUMMARY) {
+            @(
+              '### Docker consumer lane',
+              '',
+              ('- docker_reason: `{0}`' -f '{% raw %}${{ inputs.docker_reason || ''manual'' }}{% endraw %}'),
+              ('- execution_profile: `{{ cookiecutter.execution_profile }}`'),
+              ('- policy_path: `.github/comparevi/docker-lane-policy.json`'),
+              ('- authoritative_image_contract_source: `{0}`' -f $policy.authoritativeImageContractSource),
+              ('- hosted_surface_retained: `{0}`' -f [bool]$policy.hostedSurfaceRetained),
+              '- runtime ownership remains producer-owned'
+            ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+          }

--- a/{{ cookiecutter.repo_slug }}/README.md
+++ b/{{ cookiecutter.repo_slug }}/README.md
@@ -23,17 +23,25 @@ not request Docker-profile outputs in this template revision.
 Its `.github/comparevi/capabilities.json` manifest remains free of
 Docker-specific capability requirements.
 {% elif cookiecutter.execution_profile == "docker" -%}
-The selected execution profile is `docker`, which records future Docker-profile
-intent while this template revision still distributes the hosted proving
-surface.
+The selected execution profile is `docker`, which keeps hosted proving
+authoritative while also distributing the Docker workflow/documentation
+scaffold for consumer adoption.
 Its `.github/comparevi/capabilities.json` manifest records the Producer-published
 Docker capability contract and the authoritative image-contract source at
 `consumerContract.dockerImageContract`.
+This render also includes:
+- `.github/workflows/docker-profile.yml`
+- `.github/comparevi/docker-lane-policy.json`
+- `docs/DOCKER_PROFILE.md`
 {% else -%}
 The selected execution profile is `mixed`, which keeps the hosted proving
-surface and records future Docker-profile intent for follow-up template slices.
+surface and also distributes the Docker workflow/documentation scaffold.
 Its `.github/comparevi/capabilities.json` manifest records the Producer-published
 Docker capability contract and keeps the hosted surface metadata alongside it.
+This render also includes:
+- `.github/workflows/docker-profile.yml`
+- `.github/comparevi/docker-lane-policy.json`
+- `docs/DOCKER_PROFILE.md`
 {% endif %}
 
 ## CompareVI Integration
@@ -52,6 +60,11 @@ distributed by `LabviewGitHubCiTemplate`.
 - capability manifest: `.github/comparevi/capabilities.json`
 - lineage manifest: `.github/comparevi/lineage.json`
 - manual workflow scaffold: `.github/workflows/vi-history.yml`
+{% if cookiecutter.execution_profile != "hosted" %}
+- Docker workflow scaffold: `.github/workflows/docker-profile.yml`
+- Docker lane policy: `.github/comparevi/docker-lane-policy.json`
+- Docker execution doc: `docs/DOCKER_PROFILE.md`
+{% endif %}
 
 Branch-role semantics for future lineage-aware automation are:
 
@@ -70,6 +83,9 @@ capability contract in `.github/comparevi/capabilities.json`.
 - capability id: `dockerProfile`
 - authoritative image-contract source: `consumerContract.dockerImageContract`
 - Producer contract owner: `LabVIEW-Community-CI-CD/compare-vi-cli-action`
+- workflow scaffold: `.github/workflows/docker-profile.yml`
+- lane policy: `.github/comparevi/docker-lane-policy.json`
+- execution doc: `docs/DOCKER_PROFILE.md`
 
 Use a `comparevi_tools_consumer_pin` that publishes the Docker-profile
 capability contract, such as `v0.6.4-rc.2` or later.

--- a/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -45,22 +45,31 @@ released CompareVI.Tools bundle through the distributed capability manifest:
 {% if cookiecutter.execution_profile == "hosted" -%}
 - Docker-profile follow-up: not requested in this render
 - Docker capability manifest entry: omitted in this render
+- Docker workflow scaffold: omitted in this render
+- Docker lane policy: omitted in this render
 {% elif cookiecutter.execution_profile == "docker" -%}
-- Docker-profile follow-up: requested for a future template revision
+- Docker-profile follow-up: requested in this render
 - Docker capability manifest entry: `.github/comparevi/capabilities.json -> capabilities.dockerProfile`
+- Docker workflow scaffold: `.github/workflows/docker-profile.yml`
+- Docker lane policy: `.github/comparevi/docker-lane-policy.json`
+- Docker execution doc: `docs/DOCKER_PROFILE.md`
 - authoritative image-contract source: `consumerContract.dockerImageContract`
 {% else -%}
 - Docker-profile follow-up: requested alongside the hosted surface
 - Docker capability manifest entry: `.github/comparevi/capabilities.json -> capabilities.dockerProfile`
+- Docker workflow scaffold: `.github/workflows/docker-profile.yml`
+- Docker lane policy: `.github/comparevi/docker-lane-policy.json`
+- Docker execution doc: `docs/DOCKER_PROFILE.md`
 - authoritative image-contract source: `consumerContract.dockerImageContract`
 {% endif %}
 - hosted Linux + hosted Windows remain the current distributed proof surface
 
 {% if cookiecutter.execution_profile != "hosted" -%}
-The Docker capability entry is distributor metadata only.
+The Docker capability entry, lane policy, workflow scaffold, and execution doc
+are distributor surfaces only.
 Resolve the actual image contract from the pinned Producer-published
 `comparevi-tools-release.json` payload instead of inventing repository-local
-image naming rules.
+image naming rules or copying CompareVI runtime logic into this repository.
 {% endif %}
 
 ## Branch Roles

--- a/{{ cookiecutter.repo_slug }}/docs/CONSUMER_PROVING_RAIL.md
+++ b/{{ cookiecutter.repo_slug }}/docs/CONSUMER_PROVING_RAIL.md
@@ -14,11 +14,18 @@ This generated repository assumes a hosted-first proving model.
 {% if cookiecutter.execution_profile == "hosted" -%}
 - current contract: hosted-only generated surface
 {% elif cookiecutter.execution_profile == "docker" -%}
-- current contract: hosted surface plus recorded future Docker follow-up intent
+- current contract: hosted proof plus distributed Docker workflow/documentation scaffold
 {% else -%}
-- current contract: hosted surface plus recorded mixed-mode follow-up intent
+- current contract: hosted proof plus distributed Docker workflow/documentation scaffold and retained hosted surface
 {% endif %}
 - authoritative proof surface in this revision: hosted Linux + hosted Windows
+{% if cookiecutter.execution_profile != "hosted" -%}
+- distributed Docker scaffold:
+  - workflow: `.github/workflows/docker-profile.yml`
+  - lane policy: `.github/comparevi/docker-lane-policy.json`
+  - documentation: `docs/DOCKER_PROFILE.md`
+- Docker workflow scaffold is manual-by-default and does not replace hosted proof by itself
+{% endif %}
 
 ## Lineage Roles
 

--- a/{{ cookiecutter.repo_slug }}/docs/DOCKER_PROFILE.md
+++ b/{{ cookiecutter.repo_slug }}/docs/DOCKER_PROFILE.md
@@ -1,0 +1,54 @@
+# Docker Profile
+
+This generated repository includes a consumer-facing Docker workflow and
+documentation scaffold.
+
+It is distributed by `LabviewGitHubCiTemplate` and anchored to the Producer
+contract published by `compare-vi-cli-action`.
+
+## Distributed Surfaces
+
+- workflow scaffold: `.github/workflows/docker-profile.yml`
+- lane policy: `.github/comparevi/docker-lane-policy.json`
+- capability manifest: `.github/comparevi/capabilities.json`
+- authoritative image-contract source: `consumerContract.dockerImageContract`
+- CompareVI.Tools pin: `{{ cookiecutter.comparevi_tools_consumer_pin }}`
+
+## Selected Profile
+
+- execution profile: `{{ cookiecutter.execution_profile }}`
+- hosted surface retained: `{{ "true" if cookiecutter.execution_profile == "mixed" else "false" }}`
+
+{% if cookiecutter.execution_profile == "docker" -%}
+This render enables the Docker-profile scaffold without retaining a mixed-mode
+hosted surface contract inside the Docker lane policy.
+{% else -%}
+This render keeps the hosted surface and also distributes the Docker-profile
+scaffold.
+{% endif %}
+
+## Boundary
+
+This scaffold does not make the generated repository a CompareVI runtime owner.
+
+Keep these boundaries intact:
+
+- `compare-vi-cli-action` publishes the runtime/tooling contracts
+- `LabviewGitHubCiTemplate` distributes consumer-facing Docker metadata,
+  workflow scaffolds, and documentation
+- generated repositories consume the pinned release surface instead of
+  vendoring CompareVI internals
+
+## Consumer Rule
+
+Use `.github/comparevi/capabilities.json` and
+`.github/comparevi/docker-lane-policy.json` as the local source of truth for:
+
+- requested execution profile
+- pinned CompareVI.Tools release
+- authoritative image-contract source
+- whether the hosted surface remains retained
+
+Resolve the actual Docker image contract from the pinned
+`comparevi-tools-release.json` payload instead of inventing repository-local
+image naming rules.


### PR DESCRIPTION
## Summary

This completes the next Docker-profile slice in `LabviewGitHubCiTemplate`.

It adds the missing generated Docker workflow/documentation surface for `docker` and `mixed` renders:
- `.github/workflows/docker-profile.yml`
- `.github/comparevi/docker-lane-policy.json`
- `docs/DOCKER_PROFILE.md`

It also adds a `post_gen_project` hook so `hosted` renders fail closed on Docker-only outputs instead of carrying scaffold files they should not own.

## Scope

- adds the generated Docker lane policy file
- adds the generated manual Docker workflow scaffold
- adds the generated Docker consumer doc
- updates generated docs and canonical docs so they stop describing Docker scaffolds as future-only
- extends `template-smoke` to assert Docker file presence for `docker`/`mixed` and absence for `hosted`

## Validation

Local:
- cookiecutter render matrix passed for `hosted`, `docker`, and `mixed`
- Docker scaffold presence/absence assertions passed across all three profiles
- generated Docker policy/workflow/doc content checks passed for `docker` and `mixed`
- `git diff --check`

Closes #25