### PR TITLE
[comparevi]: tighten Docker scaffold receipt and template-smoke assertions (#27)

### DIFF
--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -125,10 +125,10 @@ jobs:
                   throw "Docker render should emit Docker scaffold file: $relativePath"
                 }
               }
-              if ($generatedPlatformDoc -notlike '*Docker workflow scaffold: `.github/workflows/docker-profile.yml`*') {
+              if (-not $generatedPlatformDoc.Contains('Docker workflow scaffold: `.github/workflows/docker-profile.yml`')) {
                 throw 'Docker render should declare the generated Docker workflow scaffold.'
               }
-              if ($generatedProvingDoc -notlike '*current contract: hosted proof plus distributed Docker workflow/documentation scaffold*') {
+              if (-not $generatedProvingDoc.Contains('current contract: hosted proof plus distributed Docker workflow/documentation scaffold')) {
                 throw 'Docker render should declare hosted proof plus distributed Docker scaffold.'
               }
             }
@@ -139,10 +139,10 @@ jobs:
                   throw "Mixed render should emit Docker scaffold file: $relativePath"
                 }
               }
-              if ($generatedPlatformDoc -notlike '*Docker workflow scaffold: `.github/workflows/docker-profile.yml`*') {
+              if (-not $generatedPlatformDoc.Contains('Docker workflow scaffold: `.github/workflows/docker-profile.yml`')) {
                 throw 'Mixed render should declare the generated Docker workflow scaffold.'
               }
-              if ($generatedProvingDoc -notlike '*current contract: hosted proof plus distributed Docker workflow/documentation scaffold and retained hosted surface*') {
+              if (-not $generatedProvingDoc.Contains('current contract: hosted proof plus distributed Docker workflow/documentation scaffold and retained hosted surface')) {
                 throw 'Mixed render should declare hosted proof plus distributed Docker scaffold and retained hosted surface.'
               }
             }
@@ -217,7 +217,7 @@ jobs:
                 throw 'Docker render should document the authoritative image contract source.'
               }
               $dockerDoc = Get-Content -LiteralPath $dockerDocPath -Raw
-              if ($dockerDoc -notlike '*workflow scaffold: `.github/workflows/docker-profile.yml`*') {
+              if (-not $dockerDoc.Contains('workflow scaffold: `.github/workflows/docker-profile.yml`')) {
                 throw 'Docker render should document the generated Docker workflow scaffold.'
               }
               $dockerPolicy = Get-Content -LiteralPath $dockerPolicyPath -Raw | ConvertFrom-Json -AsHashtable
@@ -232,7 +232,7 @@ jobs:
               }
               $dockerWorkflow = Get-Content -LiteralPath $dockerWorkflowPath -Raw
               foreach ($snippet in @('### Docker consumer lane', '.github/comparevi/docker-lane-policy.json', 'consumerContract.dockerImageContract', 'runtime ownership remains producer-owned')) {
-                if ($dockerWorkflow -notlike "*$snippet*") {
+                if (-not $dockerWorkflow.Contains($snippet)) {
                   throw "Docker workflow scaffold is missing required snippet: $snippet"
                 }
               }
@@ -257,7 +257,7 @@ jobs:
                 throw 'Mixed render should document the authoritative image contract source.'
               }
               $dockerDoc = Get-Content -LiteralPath $dockerDocPath -Raw
-              if ($dockerDoc -notlike '*hosted surface retained: `true`*') {
+              if (-not $dockerDoc.Contains('hosted surface retained: `true`')) {
                 throw 'Mixed render should document hosted surface retention.'
               }
               $dockerPolicy = Get-Content -LiteralPath $dockerPolicyPath -Raw | ConvertFrom-Json -AsHashtable
@@ -272,7 +272,7 @@ jobs:
               }
               $dockerWorkflow = Get-Content -LiteralPath $dockerWorkflowPath -Raw
               foreach ($snippet in @('### Docker consumer lane', '.github/comparevi/docker-lane-policy.json', 'consumerContract.dockerImageContract', 'runtime ownership remains producer-owned')) {
-                if ($dockerWorkflow -notlike "*$snippet*") {
+                if (-not $dockerWorkflow.Contains($snippet)) {
                   throw "Mixed Docker workflow scaffold is missing required snippet: $snippet"
                 }
               }

--- a/{{ cookiecutter.repo_slug }}/.github/workflows/docker-profile.yml
+++ b/{{ cookiecutter.repo_slug }}/.github/workflows/docker-profile.yml
@@ -3,10 +3,13 @@ name: docker-profile
 on:
   workflow_dispatch:
     inputs:
-      docker_reason:
+      proving_reason:
         description: Why this Docker consumer lane is being dispatched.
         required: false
         default: manual
+
+permissions:
+  contents: read
 
 jobs:
   docker-consumer-lane:
@@ -14,27 +17,61 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Read Docker scaffold contract
+      - name: Read Docker consumer lane contract
+        id: contract
         shell: pwsh
         run: |
           $capability = Get-Content -LiteralPath '.github/comparevi/capabilities.json' -Raw | ConvertFrom-Json -AsHashtable
           $policy = Get-Content -LiteralPath '.github/comparevi/docker-lane-policy.json' -Raw | ConvertFrom-Json -AsHashtable
           $dockerProfile = $capability.capabilities.dockerProfile
           if ($null -eq $dockerProfile) {
-            throw 'Missing dockerProfile capability in the generated capability manifest.'
+            throw 'Missing capabilities.dockerProfile in .github/comparevi/capabilities.json.'
           }
-          if ($policy.authoritativeImageContractSource -ne 'consumerContract.dockerImageContract') {
-            throw 'Unexpected authoritative image-contract source in the Docker lane policy.'
+          if (-not [bool]$dockerProfile.enabled) {
+            throw 'Docker capability manifest entry is present but not enabled.'
           }
+          if ($dockerProfile.authoritativeImageContractSource -ne $policy.authoritativeImageContractSource) {
+            throw 'Docker capability manifest and Docker lane policy disagree on the authoritative image contract source.'
+          }
+          if ($dockerProfile.requestedExecutionProfile -ne $policy.requestedExecutionProfile) {
+            throw 'Docker capability manifest and Docker lane policy disagree on the requested execution profile.'
+          }
+          if ($dockerProfile.authoritativeConsumerPin -ne $policy.authoritativeConsumerPin) {
+            throw 'Docker capability manifest and Docker lane policy disagree on the authoritative consumer pin.'
+          }
+          $receiptRoot = Join-Path $PWD 'tests/results/docker-profile'
+          New-Item -ItemType Directory -Path $receiptRoot -Force | Out-Null
+          $receiptPath = Join-Path $receiptRoot 'docker-profile-plan.json'
+          [ordered]@{
+            schema = 'labview-template/docker-profile-plan@v1'
+            requestedExecutionProfile = $policy.requestedExecutionProfile
+            authoritativeConsumerPin = $policy.authoritativeConsumerPin
+            authoritativeImageContractSource = $policy.authoritativeImageContractSource
+            hostedSurfaceRetained = [bool]$policy.hostedSurfaceRetained
+            lanePolicyPath = '.github/comparevi/docker-lane-policy.json'
+            capabilityManifestPath = '.github/comparevi/capabilities.json'
+            integrationDocPath = 'docs/DOCKER_PROFILE.md'
+            runtimeOwnership = 'producer-owned'
+          } | ConvertTo-Json -Depth 10 | Out-File -LiteralPath $receiptPath -Encoding utf8
+          "receipt_path=$receiptPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           if ($env:GITHUB_STEP_SUMMARY) {
             @(
               '### Docker consumer lane',
               '',
-              ('- docker_reason: `{0}`' -f '{% raw %}${{ inputs.docker_reason || ''manual'' }}{% endraw %}'),
-              ('- execution_profile: `{{ cookiecutter.execution_profile }}`'),
-              ('- policy_path: `.github/comparevi/docker-lane-policy.json`'),
+              ('- proving_reason: `{0}`' -f '{% raw %}${{ inputs.proving_reason || ''manual'' }}{% endraw %}'),
+              ('- requested_execution_profile: `{0}`' -f $policy.requestedExecutionProfile),
+              ('- authoritative_consumer_pin: `{0}`' -f $policy.authoritativeConsumerPin),
               ('- authoritative_image_contract_source: `{0}`' -f $policy.authoritativeImageContractSource),
-              ('- hosted_surface_retained: `{0}`' -f [bool]$policy.hostedSurfaceRetained),
+              ('- hosted_surface_retained: `{0}`' -f $policy.hostedSurfaceRetained.ToString().ToLowerInvariant()),
+              ('- lane_policy_path: `{0}`' -f '.github/comparevi/docker-lane-policy.json'),
+              ('- capability_manifest_path: `{0}`' -f '.github/comparevi/capabilities.json'),
+              ('- integration_doc_path: `{0}`' -f 'docs/DOCKER_PROFILE.md'),
               '- runtime ownership remains producer-owned'
             ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           }
+
+      - name: Upload Docker lane receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-profile-plan
+          path: {% raw %}${{ steps.contract.outputs.receipt_path }}{% endraw %}


### PR DESCRIPTION
## Summary

Follow-up to #25.

This tightens the shipped Docker scaffold in two places:
- `template-smoke` now uses exact substring checks for the Docker-specific code-formatted snippets instead of brittle wildcard matches
- the generated `.github/workflows/docker-profile.yml` scaffold now validates capability/policy agreement more explicitly, declares `permissions: contents: read`, and emits/uploads a deterministic receipt

## Local Proof

- local render matrix passed for `hosted`, `docker`, and `mixed`
- local content-oriented proof passed for `hosted`, `docker`, and `mixed`
- `git diff --check` passed

## Scope Boundary

This does not widen the template into CompareVI runtime ownership.
It stays consumer-facing and keeps hosted proof authoritative.

Closes #27
