### PR TITLE
docs(comparevi): codify template branch protection (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Future agents should treat the canonical template repo this way:
 - start from canonical `develop`
 - inspect open issues first
 - inspect the latest supported `template-smoke` state
+- treat `docs/policy/develop-branch-protection.json` as the checked-in
+  contract for canonical `develop` required checks
 - if no eligible issue exists, remain in monitoring mode
 - if an eligible issue exists, use that issue as the top objective
 

--- a/docs/CONSUMER_PROVING_RAIL.md
+++ b/docs/CONSUMER_PROVING_RAIL.md
@@ -34,6 +34,9 @@ standing-priority work.
 - canonical template repo
   - `template-smoke` on `push`, `pull_request`, and `workflow_dispatch` is the
     authoritative template-self-validation surface
+  - canonical `develop` branch protection now requires the full
+    `template-smoke` matrix recorded in
+    `docs/policy/develop-branch-protection.json`
 - generated execution-profile contract
   - `hosted` is the default generated profile
   - `docker` and `mixed` are accepted template inputs

--- a/docs/policy/develop-branch-protection.json
+++ b/docs/policy/develop-branch-protection.json
@@ -1,0 +1,24 @@
+{
+  "schema": "labview-template/develop-branch-protection@v1",
+  "branch": "develop",
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "comparevi-consumer-smoke (ubuntu-latest)",
+      "comparevi-consumer-smoke (windows-latest)",
+      "render (ubuntu-latest, hosted)",
+      "render (ubuntu-latest, docker)",
+      "render (ubuntu-latest, mixed)",
+      "render (windows-latest, hosted)",
+      "render (windows-latest, docker)",
+      "render (windows-latest, mixed)"
+    ]
+  },
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": false,
+  "lock_branch": false,
+  "allow_fork_syncing": false
+}


### PR DESCRIPTION
## Summary
- check in the canonical `develop` branch-protection contract under `docs/policy`
- document that canonical `develop` is gated by the `template-smoke` matrix
- keep the checked-in contract aligned with the live GitHub protection settings

## Validation
- live protection parity check against GitHub branch protection API
- `git diff --check`

Closes #32