### PR TITLE
docs(template): codify supported fork proving contract (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,12 @@ Current fork consumer proving guidance:
 - keep fork `develop` aligned to canonical `develop`
 - use manual `template-smoke` dispatches on aligned fork `develop` as the
   supported fork proof path
+- treat a successful `template-smoke` run on drifted fork `develop` as
+  insufficient by itself
 - treat fork-local `pull_request` proof as unsupported and do not reopen work
   from it by itself
+- keep the machine-readable fork proof contract in
+  `docs/policy/supported-consumer-fork-proving.json` aligned with that rule
 - when the canonical template queue is empty, monitoring-only is the correct
   terminal state
 

--- a/docs/CONSUMER_PROVING_RAIL.md
+++ b/docs/CONSUMER_PROVING_RAIL.md
@@ -47,8 +47,12 @@ standing-priority work.
   - keep fork `develop` aligned to canonical `develop`
   - treat `workflow_dispatch` on `template-smoke` from aligned `develop` as the
     supported fork consumer proof lane
+  - a successful fork smoke run on drifted fork `develop` is still not
+    supported consumer proof
   - treat fork-local `pull_request` proof as unsupported and never reopen work
     from it by itself
+  - keep the checked-in fork proving contract in
+    `docs/policy/supported-consumer-fork-proving.json` aligned with that rule
 - generated consumers
   - remain the hosted-first proving target for downstream validation
   - should not inherit fork-only proving assumptions without explicit evidence

--- a/docs/policy/supported-consumer-fork-proving.json
+++ b/docs/policy/supported-consumer-fork-proving.json
@@ -1,0 +1,25 @@
+{
+  "schema": "labview-template/supported-consumer-fork-proving@v1",
+  "canonical_repository": "LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate",
+  "canonical_branch": "develop",
+  "supported_fork_proof": {
+    "workflow": "template-smoke",
+    "branch": "develop",
+    "event": "workflow_dispatch",
+    "required_conclusion": "success",
+    "alignment_requirement": "fork develop must remain aligned to canonical develop",
+    "unsupported_signals_by_themselves": [
+      "pull_request"
+    ]
+  },
+  "supported_forks": [
+    {
+      "repository": "LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork",
+      "role": "organization-fork-proving-lane"
+    },
+    {
+      "repository": "svelderrainruiz/LabviewGitHubCiTemplate",
+      "role": "personal-fork-proving-lane"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a checked-in machine-readable contract for the supported consumer-fork proving rails
- point the canonical docs at that contract without changing template or workflow behavior
- keep the slice limited to policy/documentation parity with the already-proven fork posture

## Testing

- `Get-Content docs/policy/supported-consumer-fork-proving.json | ConvertFrom-Json | Out-Null`
- `git diff --check`