### PR TITLE
docs(template): codify Docker receipt and manifest contract (#38)

### DIFF
--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -260,7 +260,7 @@ jobs:
               }
               foreach ($snippet in @(
                 "schema = 'labview-template/docker-profile-plan@v1'",
-                "Join-Path \$receiptRoot 'docker-profile-plan.json'",
+                '$receiptPath = Join-Path $receiptRoot ''docker-profile-plan.json''',
                 "name: docker-profile-plan"
               )) {
                 if (-not $dockerWorkflow.Contains($snippet)) {
@@ -339,7 +339,7 @@ jobs:
               }
               foreach ($snippet in @(
                 "schema = 'labview-template/docker-profile-plan@v1'",
-                "Join-Path \$receiptRoot 'docker-profile-plan.json'",
+                '$receiptPath = Join-Path $receiptRoot ''docker-profile-plan.json''',
                 "name: docker-profile-plan"
               )) {
                 if (-not $dockerWorkflow.Contains($snippet)) {

--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -210,6 +210,15 @@ jobs:
               if ($dockerCapability.authoritativeConsumerPin -ne $compareViPin) {
                 throw 'Docker render should keep the CompareVI.Tools pin on the dockerProfile capability.'
               }
+              if ($dockerCapability.releaseAssetName -ne "CompareVI.Tools-$compareViPin.zip") {
+                throw 'Docker render should record the released CompareVI.Tools asset name on the dockerProfile capability.'
+              }
+              if ($dockerCapability.releaseMetadataPath -ne 'comparevi-tools-release.json') {
+                throw 'Docker render should record the CompareVI.Tools release metadata path on the dockerProfile capability.'
+              }
+              if ($dockerCapability.bundleImportPath -ne 'tools/CompareVI.Tools/CompareVI.Tools.psd1') {
+                throw 'Docker render should record the bundle import path on the dockerProfile capability.'
+              }
               if ($dockerCapability.requestedExecutionProfile -ne 'docker') {
                 throw 'Docker render should record docker as the requested execution profile.'
               }
@@ -220,8 +229,18 @@ jobs:
                 throw 'Docker render should document the authoritative image contract source.'
               }
               $dockerDoc = Get-Content -LiteralPath $dockerDocPath -Raw
-              if (-not $dockerDoc.Contains('workflow scaffold: `.github/workflows/docker-profile.yml`')) {
-                throw 'Docker render should document the generated Docker workflow scaffold.'
+              foreach ($snippet in @(
+                'workflow scaffold: `.github/workflows/docker-profile.yml`',
+                'releaseAssetName',
+                'releaseMetadataPath',
+                'bundleImportPath',
+                'receipt path: `tests/results/docker-profile/docker-profile-plan.json`',
+                'receipt schema: `labview-template/docker-profile-plan@v1`',
+                'uploaded artifact name: `docker-profile-plan`'
+              )) {
+                if (-not $dockerDoc.Contains($snippet)) {
+                  throw "Docker render should document Docker manifest or receipt contract detail: $snippet"
+                }
               }
               $dockerPolicy = Get-Content -LiteralPath $dockerPolicyPath -Raw | ConvertFrom-Json -AsHashtable
               if ($dockerPolicy.requestedExecutionProfile -ne 'docker') {
@@ -237,6 +256,15 @@ jobs:
               foreach ($snippet in $dockerWorkflowRequiredSnippets) {
                 if (-not $dockerWorkflow.Contains($snippet)) {
                   throw "Docker workflow scaffold is missing required snippet: $snippet"
+                }
+              }
+              foreach ($snippet in @(
+                "schema = 'labview-template/docker-profile-plan@v1'",
+                "Join-Path \$receiptRoot 'docker-profile-plan.json'",
+                "name: docker-profile-plan"
+              )) {
+                if (-not $dockerWorkflow.Contains($snippet)) {
+                  throw "Docker workflow scaffold is missing receipt contract snippet: $snippet"
                 }
               }
               foreach ($relativePath in $dockerForbiddenPaths) {
@@ -261,6 +289,15 @@ jobs:
               if ($dockerCapability.authoritativeImageContractSource -ne 'consumerContract.dockerImageContract') {
                 throw 'Mixed render should record the authoritative image contract source.'
               }
+              if ($dockerCapability.releaseAssetName -ne "CompareVI.Tools-$compareViPin.zip") {
+                throw 'Mixed render should record the released CompareVI.Tools asset name on the dockerProfile capability.'
+              }
+              if ($dockerCapability.releaseMetadataPath -ne 'comparevi-tools-release.json') {
+                throw 'Mixed render should record the CompareVI.Tools release metadata path on the dockerProfile capability.'
+              }
+              if ($dockerCapability.bundleImportPath -ne 'tools/CompareVI.Tools/CompareVI.Tools.psd1') {
+                throw 'Mixed render should record the bundle import path on the dockerProfile capability.'
+              }
               if ($dockerCapability.requestedExecutionProfile -ne 'mixed') {
                 throw 'Mixed render should record mixed as the requested execution profile.'
               }
@@ -271,8 +308,18 @@ jobs:
                 throw 'Mixed render should document the authoritative image contract source.'
               }
               $dockerDoc = Get-Content -LiteralPath $dockerDocPath -Raw
-              if (-not $dockerDoc.Contains('hosted surface retained: `true`')) {
-                throw 'Mixed render should document hosted surface retention.'
+              foreach ($snippet in @(
+                'hosted surface retained: `true`',
+                'releaseAssetName',
+                'releaseMetadataPath',
+                'bundleImportPath',
+                'receipt path: `tests/results/docker-profile/docker-profile-plan.json`',
+                'receipt schema: `labview-template/docker-profile-plan@v1`',
+                'uploaded artifact name: `docker-profile-plan`'
+              )) {
+                if (-not $dockerDoc.Contains($snippet)) {
+                  throw "Mixed render should document Docker manifest or receipt contract detail: $snippet"
+                }
               }
               $dockerPolicy = Get-Content -LiteralPath $dockerPolicyPath -Raw | ConvertFrom-Json -AsHashtable
               if ($dockerPolicy.requestedExecutionProfile -ne 'mixed') {
@@ -288,6 +335,15 @@ jobs:
               foreach ($snippet in $dockerWorkflowRequiredSnippets) {
                 if (-not $dockerWorkflow.Contains($snippet)) {
                   throw "Mixed Docker workflow scaffold is missing required snippet: $snippet"
+                }
+              }
+              foreach ($snippet in @(
+                "schema = 'labview-template/docker-profile-plan@v1'",
+                "Join-Path \$receiptRoot 'docker-profile-plan.json'",
+                "name: docker-profile-plan"
+              )) {
+                if (-not $dockerWorkflow.Contains($snippet)) {
+                  throw "Mixed Docker workflow scaffold is missing receipt contract snippet: $snippet"
                 }
               }
               foreach ($relativePath in $dockerForbiddenPaths) {

--- a/{{ cookiecutter.repo_slug }}/README.md
+++ b/{{ cookiecutter.repo_slug }}/README.md
@@ -82,10 +82,16 @@ capability contract in `.github/comparevi/capabilities.json`.
 
 - capability id: `dockerProfile`
 - authoritative image-contract source: `consumerContract.dockerImageContract`
+- release asset name: `CompareVI.Tools-{{ cookiecutter.comparevi_tools_consumer_pin }}.zip`
+- release metadata path: `comparevi-tools-release.json`
+- requested execution profile: `{{ cookiecutter.execution_profile }}`
+- hosted surface retained: `{{ "true" if cookiecutter.execution_profile == "mixed" else "false" }}`
 - Producer contract owner: `LabVIEW-Community-CI-CD/compare-vi-cli-action`
 - workflow scaffold: `.github/workflows/docker-profile.yml`
 - lane policy: `.github/comparevi/docker-lane-policy.json`
 - execution doc: `docs/DOCKER_PROFILE.md`
+- receipt artifact: `docker-profile-plan`
+- receipt path: `tests/results/docker-profile/docker-profile-plan.json`
 
 Use a `comparevi_tools_consumer_pin` that publishes the Docker-profile
 capability contract, such as `v0.6.4-rc.2` or later.

--- a/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -54,6 +54,7 @@ released CompareVI.Tools bundle through the distributed capability manifest:
 - Docker lane policy: `.github/comparevi/docker-lane-policy.json`
 - Docker execution doc: `docs/DOCKER_PROFILE.md`
 - authoritative image-contract source: `consumerContract.dockerImageContract`
+- receipt artifact: `docker-profile-plan`
 {% else -%}
 - Docker-profile follow-up: requested alongside the hosted surface
 - Docker capability manifest entry: `.github/comparevi/capabilities.json -> capabilities.dockerProfile`
@@ -61,6 +62,7 @@ released CompareVI.Tools bundle through the distributed capability manifest:
 - Docker lane policy: `.github/comparevi/docker-lane-policy.json`
 - Docker execution doc: `docs/DOCKER_PROFILE.md`
 - authoritative image-contract source: `consumerContract.dockerImageContract`
+- receipt artifact: `docker-profile-plan`
 {% endif %}
 - hosted Linux + hosted Windows remain the current distributed proof surface
 
@@ -70,6 +72,9 @@ are distributor surfaces only.
 Resolve the actual image contract from the pinned Producer-published
 `comparevi-tools-release.json` payload instead of inventing repository-local
 image naming rules or copying CompareVI runtime logic into this repository.
+Use the Docker workflow receipt at
+`tests/results/docker-profile/docker-profile-plan.json` to prove which pinned
+contract surface the consumer scaffold read.
 {% endif %}
 
 ## Branch Roles

--- a/{{ cookiecutter.repo_slug }}/docs/DOCKER_PROFILE.md
+++ b/{{ cookiecutter.repo_slug }}/docs/DOCKER_PROFILE.md
@@ -14,6 +14,25 @@ contract published by `compare-vi-cli-action`.
 - authoritative image-contract source: `consumerContract.dockerImageContract`
 - CompareVI.Tools pin: `{{ cookiecutter.comparevi_tools_consumer_pin }}`
 
+## Capability Manifest Contract
+
+Use `.github/comparevi/capabilities.json -> capabilities.dockerProfile` as the
+machine-readable Docker manifest contract.
+
+That entry records:
+
+- `authoritativeConsumerPin`
+- `releaseAssetName`
+- `releaseMetadataPath`
+- `bundleImportPath`
+- `authoritativeImageContractSource`
+- `requestedExecutionProfile`
+- `hostedSurfaceRetained`
+
+Those fields tell the generated consumer which released CompareVI.Tools bundle
+to trust and how to resolve the Producer-owned Docker image contract from the
+same pinned release metadata.
+
 ## Selected Profile
 
 - execution profile: `{{ cookiecutter.execution_profile }}`
@@ -52,3 +71,23 @@ Use `.github/comparevi/capabilities.json` and
 Resolve the actual Docker image contract from the pinned
 `comparevi-tools-release.json` payload instead of inventing repository-local
 image naming rules.
+
+## Workflow Receipt Contract
+
+`.github/workflows/docker-profile.yml` emits a deterministic receipt so the
+generated repository can prove which Docker contract surface it consumed.
+
+- receipt path: `tests/results/docker-profile/docker-profile-plan.json`
+- receipt schema: `labview-template/docker-profile-plan@v1`
+- uploaded artifact name: `docker-profile-plan`
+
+That receipt records:
+
+- `requestedExecutionProfile`
+- `authoritativeConsumerPin`
+- `authoritativeImageContractSource`
+- `hostedSurfaceRetained`
+- `lanePolicyPath`
+- `capabilityManifestPath`
+- `integrationDocPath`
+- `runtimeOwnership`


### PR DESCRIPTION
## Summary

- document the existing Docker manifest fields in the generated consumer docs
- document the deterministic Docker workflow receipt path, schema, and artifact name
- tighten `template-smoke` so Docker and mixed renders fail closed if those manifest or receipt details drift

## Testing

- `git diff --check`