### PR TITLE
docs(template): codify docker receipt schema contract (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ In this revision:
   compare runtime logic into the template
 - the checked-in governance proof contract for those surfaces lives in
   `docs/policy/docker-execution-profile-governance-surface.json`
+- the checked-in Docker receipt schema for descendant-facing proof lives in
+  `docs/schemas/labview-template-docker-profile-plan-v1.schema.json`
 
 ## VI History Capability Distribution
 

--- a/docs/CONSUMER_PROVING_RAIL.md
+++ b/docs/CONSUMER_PROVING_RAIL.md
@@ -45,6 +45,8 @@ standing-priority work.
     adoption
   - the checked-in execution-profile governance proof contract lives in
     `docs/policy/docker-execution-profile-governance-surface.json`
+  - the checked-in Docker receipt schema for that scaffold lives in
+    `docs/schemas/labview-template-docker-profile-plan-v1.schema.json`
 - consumer forks
   - keep fork `develop` aligned to canonical `develop`
   - treat `workflow_dispatch` on `template-smoke` from aligned `develop` as the

--- a/docs/schemas/labview-template-docker-profile-plan-v1.schema.json
+++ b/docs/schemas/labview-template-docker-profile-plan-v1.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/blob/develop/docs/schemas/labview-template-docker-profile-plan-v1.schema.json",
+  "title": "LabVIEW Template Docker Profile Plan Receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "requestedExecutionProfile",
+    "authoritativeConsumerPin",
+    "authoritativeImageContractSource",
+    "hostedSurfaceRetained",
+    "lanePolicyPath",
+    "capabilityManifestPath",
+    "integrationDocPath",
+    "runtimeOwnership"
+  ],
+  "properties": {
+    "schema": {
+      "const": "labview-template/docker-profile-plan@v1"
+    },
+    "requestedExecutionProfile": {
+      "type": "string",
+      "enum": [
+        "docker",
+        "mixed"
+      ]
+    },
+    "authoritativeConsumerPin": {
+      "type": "string",
+      "minLength": 1
+    },
+    "authoritativeImageContractSource": {
+      "const": "consumerContract.dockerImageContract"
+    },
+    "hostedSurfaceRetained": {
+      "type": "boolean"
+    },
+    "lanePolicyPath": {
+      "const": ".github/comparevi/docker-lane-policy.json"
+    },
+    "capabilityManifestPath": {
+      "const": ".github/comparevi/capabilities.json"
+    },
+    "integrationDocPath": {
+      "const": "docs/DOCKER_PROFILE.md"
+    },
+    "runtimeOwnership": {
+      "const": "producer-owned"
+    }
+  }
+}

--- a/tests/Test-TemplateSmokeRender.ps1
+++ b/tests/Test-TemplateSmokeRender.ps1
@@ -12,6 +12,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$dockerReceiptSchemaPath = Join-Path $repoRoot 'docs/schemas/labview-template-docker-profile-plan-v1.schema.json'
 $runnerTemp = if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) { [System.IO.Path]::GetTempPath() } else { $env:RUNNER_TEMP }
 $outputRoot = Join-Path $runnerTemp 'cookiecutter-render'
 New-Item -ItemType Directory -Path $outputRoot -Force | Out-Null
@@ -282,7 +283,11 @@ else {
       if (-not (Test-Path -LiteralPath $emittedReceiptPath -PathType Leaf)) {
         throw 'Docker render should emit a Docker receipt when the receipt helper runs.'
       }
-      $dockerReceipt = Get-Content -LiteralPath $emittedReceiptPath -Raw | ConvertFrom-Json -AsHashtable
+      $dockerReceiptJson = Get-Content -LiteralPath $emittedReceiptPath -Raw
+      if (-not (Test-Json -Json $dockerReceiptJson -SchemaFile $dockerReceiptSchemaPath)) {
+        throw 'Docker receipt should validate against the checked-in Docker receipt schema.'
+      }
+      $dockerReceipt = $dockerReceiptJson | ConvertFrom-Json -AsHashtable
       if ($dockerReceipt.schema -ne 'labview-template/docker-profile-plan@v1') {
         throw 'Docker receipt should record the documented schema.'
       }
@@ -399,7 +404,11 @@ else {
       if (-not (Test-Path -LiteralPath $emittedReceiptPath -PathType Leaf)) {
         throw 'Mixed render should emit a Docker receipt when the receipt helper runs.'
       }
-      $dockerReceipt = Get-Content -LiteralPath $emittedReceiptPath -Raw | ConvertFrom-Json -AsHashtable
+      $dockerReceiptJson = Get-Content -LiteralPath $emittedReceiptPath -Raw
+      if (-not (Test-Json -Json $dockerReceiptJson -SchemaFile $dockerReceiptSchemaPath)) {
+        throw 'Mixed receipt should validate against the checked-in Docker receipt schema.'
+      }
+      $dockerReceipt = $dockerReceiptJson | ConvertFrom-Json -AsHashtable
       if ($dockerReceipt.schema -ne 'labview-template/docker-profile-plan@v1') {
         throw 'Mixed receipt should record the documented schema.'
       }

--- a/{{ cookiecutter.repo_slug }}/README.md
+++ b/{{ cookiecutter.repo_slug }}/README.md
@@ -93,6 +93,7 @@ capability contract in `.github/comparevi/capabilities.json`.
 - receipt helper: `.github/comparevi/Emit-DockerProfileReceipt.ps1`
 - receipt artifact: `docker-profile-plan`
 - receipt path: `tests/results/docker-profile/docker-profile-plan.json`
+- canonical receipt schema source: `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/docs/schemas/labview-template-docker-profile-plan-v1.schema.json`
 
 Use a `comparevi_tools_consumer_pin` that publishes the Docker-profile
 capability contract, such as `v0.6.4-rc.2` or later.

--- a/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -56,6 +56,7 @@ released CompareVI.Tools bundle through the distributed capability manifest:
 - receipt helper: `.github/comparevi/Emit-DockerProfileReceipt.ps1`
 - authoritative image-contract source: `consumerContract.dockerImageContract`
 - receipt artifact: `docker-profile-plan`
+- canonical receipt schema source: `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/docs/schemas/labview-template-docker-profile-plan-v1.schema.json`
 {% else -%}
 - Docker-profile follow-up: requested alongside the hosted surface
 - Docker capability manifest entry: `.github/comparevi/capabilities.json -> capabilities.dockerProfile`
@@ -65,6 +66,7 @@ released CompareVI.Tools bundle through the distributed capability manifest:
 - receipt helper: `.github/comparevi/Emit-DockerProfileReceipt.ps1`
 - authoritative image-contract source: `consumerContract.dockerImageContract`
 - receipt artifact: `docker-profile-plan`
+- canonical receipt schema source: `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/docs/schemas/labview-template-docker-profile-plan-v1.schema.json`
 {% endif %}
 - hosted Linux + hosted Windows remain the current distributed proof surface
 

--- a/{{ cookiecutter.repo_slug }}/docs/DOCKER_PROFILE.md
+++ b/{{ cookiecutter.repo_slug }}/docs/DOCKER_PROFILE.md
@@ -80,6 +80,7 @@ generated repository can prove which Docker contract surface it consumed.
 - receipt helper: `.github/comparevi/Emit-DockerProfileReceipt.ps1`
 - receipt path: `tests/results/docker-profile/docker-profile-plan.json`
 - receipt schema: `labview-template/docker-profile-plan@v1`
+- canonical schema source: `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/docs/schemas/labview-template-docker-profile-plan-v1.schema.json`
 - uploaded artifact name: `docker-profile-plan`
 
 That receipt records:


### PR DESCRIPTION
## Summary
- add a checked-in schema for generated Docker profile receipts
- point template and generated docs at the canonical schema source
- validate emitted docker and mixed receipts against the schema in template smoke

## Testing
- pwsh -NoLogo -NoProfile -File tests/Test-TemplateSmokeRender.ps1 -ExecutionProfile hosted
- pwsh -NoLogo -NoProfile -File tests/Test-TemplateSmokeRender.ps1 -ExecutionProfile docker
- pwsh -NoLogo -NoProfile -File tests/Test-TemplateSmokeRender.ps1 -ExecutionProfile mixed
- git diff --check

Closes #42
