### PR TITLE
docs(template): codify docker lane-policy schema contract (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ In this revision:
   compare runtime logic into the template
 - the checked-in governance proof contract for those surfaces lives in
   `docs/policy/docker-execution-profile-governance-surface.json`
+- the checked-in Docker lane-policy schema for descendant-facing policy proof
+  lives in `docs/schemas/labview-template-docker-lane-policy-v1.schema.json`
 - the checked-in Docker receipt schema for descendant-facing proof lives in
   `docs/schemas/labview-template-docker-profile-plan-v1.schema.json`
 

--- a/docs/CONSUMER_PROVING_RAIL.md
+++ b/docs/CONSUMER_PROVING_RAIL.md
@@ -45,6 +45,8 @@ standing-priority work.
     adoption
   - the checked-in execution-profile governance proof contract lives in
     `docs/policy/docker-execution-profile-governance-surface.json`
+  - the checked-in Docker lane-policy schema for that scaffold lives in
+    `docs/schemas/labview-template-docker-lane-policy-v1.schema.json`
   - the checked-in Docker receipt schema for that scaffold lives in
     `docs/schemas/labview-template-docker-profile-plan-v1.schema.json`
 - consumer forks

--- a/docs/schemas/labview-template-docker-lane-policy-v1.schema.json
+++ b/docs/schemas/labview-template-docker-lane-policy-v1.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/blob/develop/docs/schemas/labview-template-docker-lane-policy-v1.schema.json",
+  "title": "LabVIEW Template Docker Lane Policy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "distributionRole",
+    "upstreamProducerRepository",
+    "authoritativeConsumerPin",
+    "requestedExecutionProfile",
+    "hostedSurfaceRetained",
+    "authoritativeImageContractSource",
+    "notes"
+  ],
+  "properties": {
+    "schema": {
+      "const": "labview-template/docker-lane-policy@v1"
+    },
+    "distributionRole": {
+      "const": "template-distributor"
+    },
+    "upstreamProducerRepository": {
+      "const": "LabVIEW-Community-CI-CD/compare-vi-cli-action"
+    },
+    "authoritativeConsumerPin": {
+      "type": "string",
+      "minLength": 1
+    },
+    "requestedExecutionProfile": {
+      "enum": [
+        "docker",
+        "mixed"
+      ]
+    },
+    "hostedSurfaceRetained": {
+      "type": "boolean"
+    },
+    "authoritativeImageContractSource": {
+      "const": "consumerContract.dockerImageContract"
+    },
+    "notes": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "Use this file together with .github/comparevi/capabilities.json as the local Docker scaffold contract."
+        },
+        {
+          "const": "Hosted Linux and hosted Windows remain authoritative until the consumer explicitly adopts Docker-backed proof."
+        }
+      ],
+      "items": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "requestedExecutionProfile": {
+            "const": "docker"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "hostedSurfaceRetained": {
+            "const": false
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "requestedExecutionProfile": {
+            "const": "mixed"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "hostedSurfaceRetained": {
+            "const": true
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/Test-TemplateSmokeRender.ps1
+++ b/tests/Test-TemplateSmokeRender.ps1
@@ -12,6 +12,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$dockerLanePolicySchemaPath = Join-Path $repoRoot 'docs/schemas/labview-template-docker-lane-policy-v1.schema.json'
 $dockerReceiptSchemaPath = Join-Path $repoRoot 'docs/schemas/labview-template-docker-profile-plan-v1.schema.json'
 $runnerTemp = if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) { [System.IO.Path]::GetTempPath() } else { $env:RUNNER_TEMP }
 $outputRoot = Join-Path $runnerTemp 'cookiecutter-render'
@@ -243,6 +244,7 @@ else {
         'releaseAssetName',
         'releaseMetadataPath',
         'bundleImportPath',
+        'canonical lane-policy schema source: `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/docs/schemas/labview-template-docker-lane-policy-v1.schema.json`',
         'receipt path: `tests/results/docker-profile/docker-profile-plan.json`',
         'receipt schema: `labview-template/docker-profile-plan@v1`',
         'uploaded artifact name: `docker-profile-plan`'
@@ -252,7 +254,11 @@ else {
         }
       }
 
-      $dockerPolicy = Get-Content -LiteralPath $dockerPolicyPath -Raw | ConvertFrom-Json -AsHashtable
+      $dockerPolicyJson = Get-Content -LiteralPath $dockerPolicyPath -Raw
+      if (-not (Test-Json -Json $dockerPolicyJson -SchemaFile $dockerLanePolicySchemaPath)) {
+        throw 'Docker lane policy should validate against the checked-in Docker lane-policy schema.'
+      }
+      $dockerPolicy = $dockerPolicyJson | ConvertFrom-Json -AsHashtable
       if ($dockerPolicy.requestedExecutionProfile -ne 'docker') {
         throw 'Docker lane policy should record docker as the requested execution profile.'
       }
@@ -364,6 +370,7 @@ else {
         'releaseAssetName',
         'releaseMetadataPath',
         'bundleImportPath',
+        'canonical lane-policy schema source: `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/docs/schemas/labview-template-docker-lane-policy-v1.schema.json`',
         'receipt path: `tests/results/docker-profile/docker-profile-plan.json`',
         'receipt schema: `labview-template/docker-profile-plan@v1`',
         'uploaded artifact name: `docker-profile-plan`'
@@ -373,7 +380,11 @@ else {
         }
       }
 
-      $dockerPolicy = Get-Content -LiteralPath $dockerPolicyPath -Raw | ConvertFrom-Json -AsHashtable
+      $dockerPolicyJson = Get-Content -LiteralPath $dockerPolicyPath -Raw
+      if (-not (Test-Json -Json $dockerPolicyJson -SchemaFile $dockerLanePolicySchemaPath)) {
+        throw 'Mixed lane policy should validate against the checked-in Docker lane-policy schema.'
+      }
+      $dockerPolicy = $dockerPolicyJson | ConvertFrom-Json -AsHashtable
       if ($dockerPolicy.requestedExecutionProfile -ne 'mixed') {
         throw 'Mixed lane policy should record mixed as the requested execution profile.'
       }

--- a/{{ cookiecutter.repo_slug }}/README.md
+++ b/{{ cookiecutter.repo_slug }}/README.md
@@ -89,6 +89,8 @@ capability contract in `.github/comparevi/capabilities.json`.
 - Producer contract owner: `LabVIEW-Community-CI-CD/compare-vi-cli-action`
 - workflow scaffold: `.github/workflows/docker-profile.yml`
 - lane policy: `.github/comparevi/docker-lane-policy.json`
+- lane-policy schema: `labview-template/docker-lane-policy@v1`
+- canonical lane-policy schema source: `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/docs/schemas/labview-template-docker-lane-policy-v1.schema.json`
 - execution doc: `docs/DOCKER_PROFILE.md`
 - receipt helper: `.github/comparevi/Emit-DockerProfileReceipt.ps1`
 - receipt artifact: `docker-profile-plan`

--- a/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
+++ b/{{ cookiecutter.repo_slug }}/docs/COMPAREVI_PLATFORM_INTEGRATION.md
@@ -52,6 +52,7 @@ released CompareVI.Tools bundle through the distributed capability manifest:
 - Docker capability manifest entry: `.github/comparevi/capabilities.json -> capabilities.dockerProfile`
 - Docker workflow scaffold: `.github/workflows/docker-profile.yml`
 - Docker lane policy: `.github/comparevi/docker-lane-policy.json`
+- canonical lane-policy schema source: `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/docs/schemas/labview-template-docker-lane-policy-v1.schema.json`
 - Docker execution doc: `docs/DOCKER_PROFILE.md`
 - receipt helper: `.github/comparevi/Emit-DockerProfileReceipt.ps1`
 - authoritative image-contract source: `consumerContract.dockerImageContract`
@@ -62,6 +63,7 @@ released CompareVI.Tools bundle through the distributed capability manifest:
 - Docker capability manifest entry: `.github/comparevi/capabilities.json -> capabilities.dockerProfile`
 - Docker workflow scaffold: `.github/workflows/docker-profile.yml`
 - Docker lane policy: `.github/comparevi/docker-lane-policy.json`
+- canonical lane-policy schema source: `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/docs/schemas/labview-template-docker-lane-policy-v1.schema.json`
 - Docker execution doc: `docs/DOCKER_PROFILE.md`
 - receipt helper: `.github/comparevi/Emit-DockerProfileReceipt.ps1`
 - authoritative image-contract source: `consumerContract.dockerImageContract`

--- a/{{ cookiecutter.repo_slug }}/docs/DOCKER_PROFILE.md
+++ b/{{ cookiecutter.repo_slug }}/docs/DOCKER_PROFILE.md
@@ -67,6 +67,8 @@ Use `.github/comparevi/capabilities.json` and
 - pinned CompareVI.Tools release
 - authoritative image-contract source
 - whether the hosted surface remains retained
+- lane-policy schema: `labview-template/docker-lane-policy@v1`
+- canonical lane-policy schema source: `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/docs/schemas/labview-template-docker-lane-policy-v1.schema.json`
 
 Resolve the actual Docker image contract from the pinned
 `comparevi-tools-release.json` payload instead of inventing repository-local


### PR DESCRIPTION
## Summary
- add a checked-in schema for generated Docker lane-policy JSON
- point template and generated docs at the canonical lane-policy schema source
- validate rendered docker and mixed lane policy files against that schema in template smoke

## Testing
- pwsh -NoLogo -NoProfile -File tests/Test-TemplateSmokeRender.ps1 -ExecutionProfile hosted
- pwsh -NoLogo -NoProfile -File tests/Test-TemplateSmokeRender.ps1 -ExecutionProfile docker
- pwsh -NoLogo -NoProfile -File tests/Test-TemplateSmokeRender.ps1 -ExecutionProfile mixed
- git diff --check

Closes #44
