### PR TITLE
chore: pin compare-vi consumer to v0.6.4

### DIFF
--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -30,7 +30,7 @@ jobs:
         id: render
         shell: pwsh
         run: |
-          & ./tests/Test-TemplateSmokeRender.ps1 -ExecutionProfile '${{ matrix.execution_profile }}' -CompareViPin 'v0.6.3'
+          & ./tests/Test-TemplateSmokeRender.ps1 -ExecutionProfile '${{ matrix.execution_profile }}' -CompareViPin 'v0.6.4'
 
       - name: Upload rendered sample
         uses: actions/upload-artifact@v4
@@ -50,7 +50,7 @@ jobs:
 
       - id: comparevi
         name: CompareVI consumer smoke
-        uses: LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3
+        uses: LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.4
         with:
           base: tests/fixtures/comparevi/placeholder.vi
           head: tests/fixtures/comparevi/placeholder.vi
@@ -69,7 +69,7 @@ jobs:
             @(
               '### CompareVI consumer smoke',
               '',
-              '- pinned_ref: `LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3`',
+              '- pinned_ref: `LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.4`',
               ('- runner_os: `{0}`' -f $env:RUNNER_OS),
               ('- shortCircuitedIdentical: `{0}`' -f '${{ steps.comparevi.outputs.shortCircuitedIdentical }}'),
               ('- diff: `{0}`' -f '${{ steps.comparevi.outputs.diff }}')

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cookiecutter https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate.
   repo_slug="labview-hosted-ci-sample"
   github_owner="LabVIEW-Community-CI-CD"
   execution_profile="hosted"
-  comparevi_tools_consumer_pin="v0.6.3"
+  comparevi_tools_consumer_pin="v0.6.4"
   enable_vi_history_capability="yes"
 ```
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,7 +10,7 @@
     "docker",
     "mixed"
   ],
-  "comparevi_tools_consumer_pin": "v0.6.3",
+  "comparevi_tools_consumer_pin": "v0.6.4",
   "enable_vi_history_capability": [
     "yes",
     "no"

--- a/docs/VI_HISTORY_CAPABILITY_DISTRIBUTION.md
+++ b/docs/VI_HISTORY_CAPABILITY_DISTRIBUTION.md
@@ -36,7 +36,7 @@ records the Producer-published Docker capability contract pointer:
 
 ## Current Pin
 
-The default upstream consumer pin is `v0.6.3`.
+The default upstream consumer pin is `v0.6.4`.
 
 That pin is intentionally stored in the template prompt surface so future
 template revisions can advance the pin without forcing downstream repos to copy

--- a/tests/Test-TemplateSmokeRender.ps1
+++ b/tests/Test-TemplateSmokeRender.ps1
@@ -5,7 +5,7 @@ param(
   [string]$ExecutionProfile,
 
   [Parameter()]
-  [string]$CompareViPin = 'v0.6.3'
+  [string]$CompareViPin = 'v0.6.4'
 )
 
 Set-StrictMode -Version Latest

--- a/{{ cookiecutter.repo_slug }}/README.md
+++ b/{{ cookiecutter.repo_slug }}/README.md
@@ -101,6 +101,6 @@ capability contract in `.github/comparevi/capabilities.json`.
 - canonical receipt schema source: `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/docs/schemas/labview-template-docker-profile-plan-v1.schema.json`
 
 Use a `comparevi_tools_consumer_pin` that publishes the Docker-profile
-capability contract, such as `v0.6.3` or a later supported stable `v0.6.x`
+capability contract, such as `v0.6.4` or a later supported stable `v0.6.x`
 release.
 {% endif %}


### PR DESCRIPTION
## Summary
- repin the default compare-vi consumer surfaces from v0.6.3 to v0.6.4
- align the template smoke default and downstream docs with the new stable upstream tag

## Validation
- git diff --check
- local smoke render blocked because cookiecutter is not installed in this shell; defer to repo CI
